### PR TITLE
new passing of 10m wind explicitly to ww3 -

### DIFF
--- a/datm/datm_datamode_core2_mod.F90
+++ b/datm/datm_datamode_core2_mod.F90
@@ -40,6 +40,8 @@ module datm_datamode_core2_mod
   ! export state pointers
   real(r8), pointer :: Sa_u(:)       => null()
   real(r8), pointer :: Sa_v(:)       => null()
+  real(r8), pointer :: Sa_u10m(:)    => null()
+  real(r8), pointer :: Sa_v10m(:)    => null()
   real(r8), pointer :: Sa_z(:)       => null()
   real(r8), pointer :: Sa_tbot(:)    => null()
   real(r8), pointer :: Sa_ptem(:)    => null()
@@ -115,6 +117,8 @@ contains
     call dshr_fldList_add(fldsExport, 'Sa_z'       )
     call dshr_fldList_add(fldsExport, 'Sa_u'       )
     call dshr_fldList_add(fldsExport, 'Sa_v'       )
+    call dshr_fldList_add(fldsExport, 'Sa_u10m'    )
+    call dshr_fldList_add(fldsExport, 'Sa_v10m'    )
     call dshr_fldList_add(fldsExport, 'Sa_ptem'    )
     call dshr_fldList_add(fldsExport, 'Sa_dens'    )
     call dshr_fldList_add(fldsExport, 'Sa_pslv'    )
@@ -219,6 +223,10 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_v'       , fldptr1=Sa_v       , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_u10m'    , fldptr1=Sa_u10m    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_v10m'    , fldptr1=Sa_v10m    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_tbot'    , fldptr1=Sa_tbot    , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_pbot'    , fldptr1=Sa_pbot    , rc=rc)
@@ -314,6 +322,10 @@ contains
        vprime = Sa_v(n)*windFactor(n)
        Sa_u(n) = uprime*cos(winddFactor(n)*degtorad) - vprime*sin(winddFactor(n)*degtorad)
        Sa_v(n) = uprime*sin(winddFactor(n)*degtorad) + vprime*cos(winddFactor(n)*degtorad)
+
+       ! Set Sa_u10m and Sa_v10m to Sa_u and Sa_v
+       Sa_u10m(n) = Sa_u(n)
+       Sa_v10m(n) = Sa_v(n)
 
        !--- density and pslv taken directly from input stream, set pbot ---
        Sa_pbot(n) = Sa_pslv(n)

--- a/datm/datm_datamode_jra_mod.F90
+++ b/datm/datm_datamode_jra_mod.F90
@@ -25,6 +25,10 @@ module datm_datamode_jra_mod
 
   ! export state pointers
   real(r8), pointer :: Sa_z(:)       => null()
+  real(r8), pointer :: Sa_u(:)       => null()
+  real(r8), pointer :: Sa_v(:)       => null()
+  real(r8), pointer :: Sa_u10m(:)    => null()
+  real(r8), pointer :: Sa_v10m(:)    => null()
   real(r8), pointer :: Sa_tbot(:)    => null()
   real(r8), pointer :: Sa_ptem(:)    => null()
   real(r8), pointer :: Sa_shum(:)    => null()
@@ -88,6 +92,8 @@ contains
     call dshr_fldList_add(fldsExport, 'Sa_z'       )
     call dshr_fldList_add(fldsExport, 'Sa_u'       )
     call dshr_fldList_add(fldsExport, 'Sa_v'       )
+    call dshr_fldList_add(fldsExport, 'Sa_u10m'    )
+    call dshr_fldList_add(fldsExport, 'Sa_v10m'    )
     call dshr_fldList_add(fldsExport, 'Sa_ptem'    )
     call dshr_fldList_add(fldsExport, 'Sa_dens'    )
     call dshr_fldList_add(fldsExport, 'Sa_pslv'    )
@@ -174,6 +180,14 @@ contains
     call shr_strdata_get_stream_pointer( sdat, 'Faxa_swdn'  , strm_swdn  , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
+    call dshr_state_getfldptr(exportState, 'Sa_u'       , fldptr1=Sa_u       , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_v'       , fldptr1=Sa_v       , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_u10m'    , fldptr1=Sa_u10m    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Sa_v10m'    , fldptr1=Sa_v10m    , rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_z'       , fldptr1=Sa_z       , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Sa_tbot'    , fldptr1=Sa_tbot    , rc=rc)
@@ -252,6 +266,10 @@ contains
        Sa_z(n) = 10.0_R8
        Sa_pbot(n) = Sa_pslv(n)
        Sa_ptem(n) = Sa_tbot(n)
+
+       ! Set Sa_u10m and Sa_v10m to Sa_u and Sa_v
+       Sa_u10m(n) = Sa_u(n)
+       Sa_v10m(n) = Sa_v(n)
 
        ! density computation for JRA55 forcing
        Sa_dens(n) = Sa_pbot(n)/(rdair*Sa_tbot(n)*(1 + 0.608*Sa_shum(n)))


### PR DESCRIPTION
### Description of changes
The correct winds to send to ww3 are 10m winds not bottom level atm winds. 

### Specific notes
CAM has been changed to now send out both bottom level and 10m winds. However, for DATM the bottom level winds are actually equal to the 10m winds. But duplicates need to exist because of the naming convention in both CMEPS and WW3.

Contributors other than yourself, if any: None

CDEPS Issues Fixed (include github issue #):

Are there dependencies on other component PRs (if so list):  No. This PR is backwards compatible. However, for things to work correctly in WW3DEV, this PR and also PRs from CMEPS, CAM and WW3DEV will be needed.

Are changes expected to change answers: BFB

Any User Interface Changes (namelist or namelist defaults changes): No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc): This will be summarized.

Hashes used for testing: 

