### PR TITLE
fixes memory leak for stream_vectors and supports RFYnnnn data modes

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -355,6 +355,9 @@ contains
     if ( trim(datamode) == 'CORE2_NYF'    .or. &
          trim(datamode) == 'CORE2_IAF'    .or. &
          trim(datamode) == 'CORE_IAF_JRA' .or. &
+         trim(datamode) == 'CORE_RYF8485_JRA' .or. &
+         trim(datamode) == 'CORE_RYF9091_JRA' .or. &
+         trim(datamode) == 'CORE_RYF0304_JRA' .or. &
          trim(datamode) == 'CLMNCEP'      .or. &
          trim(datamode) == 'CPLHIST'      .or. &
          trim(datamode) == 'GEFS'         .or. &
@@ -371,7 +374,7 @@ contains
        call datm_datamode_core2_advertise(exportState, fldsExport, flds_scalar_name, &
             flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    case ('CORE_IAF_JRA')
+    case ('CORE_IAF_JRA', 'CORE_RYF8485_JRA', 'CORE_RYF9091_JRA', 'CORE_RYF0304_JRA')
        call datm_datamode_jra_advertise(exportState, fldsExport, flds_scalar_name, &
             flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -620,7 +623,7 @@ contains
        case('CORE2_NYF','CORE2_IAF')
           call datm_datamode_core2_init_pointers(exportState, sdat, datamode, factorfn_mesh, factorfn_data, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       case('CORE_IAF_JRA')
+       case ('CORE_IAF_JRA', 'CORE_RYF8485_JRA', 'CORE_RYF9091_JRA', 'CORE_RYF0304_JRA')
           call datm_datamode_jra_init_pointers(exportState, sdat, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case('CLMNCEP')
@@ -645,7 +648,7 @@ contains
           call shr_get_rpointer_name(gcomp, 'atm', target_ymd, target_tod, rpfile, 'read', rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           select case (trim(datamode))
-          case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA','CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
+          case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA','CORE_RYF8485_JRA','CORE_RYF9091_JRA','CORE_RYF0304_JRA','CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
              call dshr_restart_read(restfilm, rpfile, logunit, my_task, mpicom, sdat, rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           case default
@@ -685,7 +688,7 @@ contains
        call datm_datamode_core2_advance(datamode, target_ymd, target_tod, target_mon, &
             sdat%model_calendar, factorfn_mesh, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    case('CORE_IAF_JRA')
+    case('CORE_IAF_JRA','CORE_RYF8485_JRA','CORE_RYF9091_JRA','CORE_RYF0304_JRA')
        call datm_datamode_jra_advance(exportstate, target_ymd, target_tod, sdat%model_calendar, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case('CLMNCEP')
@@ -713,7 +716,7 @@ contains
        call shr_get_rpointer_name(gcomp, 'atm', target_ymd, target_tod, rpfile, 'write', rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        select case (trim(datamode))
-       case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA','CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
+       case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA','CORE_RYF8485_JRA','CORE_RYF9091_JRA','CORE_RYF0304_JRA','CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
           call dshr_restart_write(rpfile, case_name, 'datm', inst_suffix, target_ymd, target_tod, logunit, &
                my_task, sdat, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -42,7 +42,7 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,1PT,CLMCRUJRA2024,CLMCRUNCEPv7,CLMGSWP3v1,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018,CORE_IAF_JRA_1p5_2023,ERA5,SIMPLE</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,1PT,CLMCRUJRA2024,CLMCRUNCEPv7,CLMGSWP3v1,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018,CORE_IAF_JRA_1p5_2023,CORE_RYF8485_JRA,CORE_RYF9091_JRA,CORE_RYF0304_JRA,ERA5,SIMPLE</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -56,6 +56,9 @@
       <value compset="DATM%JRA">CORE_IAF_JRA</value>
       <value compset="DATM%JRA-1p4-2018">CORE_IAF_JRA_1p4_2018</value>
       <value compset="DATM%JRA-1p5-2023">CORE_IAF_JRA_1p5_2023</value>
+      <value compset="DATM%JRA-RYF8485">CORE_RYF8485_JRA</value>
+      <value compset="DATM%JRA-RYF9091">CORE_RYF9091_JRA</value>
+      <value compset="DATM%JRA-RYF0304">CORE_RYF0304_JRA</value>
       <value compset="DATM%QIA">CLM_QIAN</value>
       <value compset="DATM%WISOQIA">CLM_QIAN_WISO</value>
       <value compset="DATM%CRUJRA2024">CLMCRUJRA2024</value>

--- a/datm/cime_config/namelist_definition_datm.xml
+++ b/datm/cime_config/namelist_definition_datm.xml
@@ -90,7 +90,7 @@
     <type>char</type>
     <category>datm</category>
     <group>datm_nml</group>
-    <valid_values>CLMNCEP,CORE2_NYF,CORE2_IAF,CORE_IAF_JRA,ERA5,SIMPLE,CPLHIST,1PT</valid_values>
+    <valid_values>CLMNCEP,CORE2_NYF,CORE2_IAF,CORE_IAF_JRA,CORE_RYF8485_JRA,CORE_RYF9091_JRA,CORE_RYF0304_JRA,ERA5,SIMPLE,CPLHIST,1PT</valid_values>
     <desc>
       general method that operates on the data.
       ----datamode = "CPLHIST"----
@@ -115,6 +115,12 @@
       Clm Dyn doi 10.1007/s00382-008-0441-3.
       ----datamode = "CORE_IAF_JRA"----
       JRA55 intra-annual year forcing
+      ----datamode = "CORE_RYF8485_JRA"----
+      JRA55 Repeat Year Forcing 1984-1985
+      ----datamode = "CORE_RYF9091_JRA"----
+      JRA55 Repeat Year Forcing 1990-1991
+      ----datamode = "CORE_RYF0304_JRA"----
+      JRA55 Repeat Year Forcing 2003-2004
       ----datamode = "CLMNCEP"----
       In conjunction with NCEP climatological atmosphere data, provides the
       atmosphere forcing favored by the Land Model Working Group when


### PR DESCRIPTION
### Description of changes
fixes memory leak for stream_vectors and supports RFYnnnn data modes

Contributors other than yourself, if any: @matsbn 

CDEPS Issues Fixed: #15 

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers: bfb

Any User Interface Changes (namelist or namelist defaults changes): No

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
New additional test in aux_cdeps_noresm:
    SMS_Ld5.TL319_tn14.1850_DATM%JRA-RYF8485_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP.betzy_gnu
Ran aux_cdeps_noresm for cdeps1.0.70_noresm_v2 and generated baselines 
Ran aux_cdeps_noresm with this branch and compared to cdeps1.0.70_noresm_v2 (everything passed) and generated new baselines cdeps1.0.70_noresm_v3 
Ran NOIIAJRARYF8485OC.TL319_tn14 for 22 months without sign of memory leak.

Hashes used for testing:
noresm3_0_alpha03 with this CDEPS branch

