### PR TITLE
Make 1st timestep same as cam7 for nextsw_cday

### DIFF
--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -881,6 +881,8 @@ contains
           ! or later.
           if (mod(tod,delta_radsw) == 0 .and. stepno > 0) then
              nextsw_cday = julday + 1*dtime/shr_const_cday
+          elseif (stepno == 0) then
+             nextsw_cday = julday + (1+liradsw)*dtime/shr_const_cday
           else
              nextsw_cday = -1._r8
           end if


### PR DESCRIPTION
### Description of changes

  Change what datm sends via `nextsw_cday` on the first timestep when `nextsw_cday_calc_cam7=.true.`.
  Previously, it would send -1, while cam7 sends 1.062... 

### Specific notes
   Needed for NorESMhub/CTSM#136
Contributors other than yourself, if any:
No
CDEPS Issues Fixed (include github issue #):
No
Are there dependencies on other component PRs (if so list):
No
Are changes expected to change answers (bfb, different to roundoff, more substantial):
May be for compsets with cam7 cplhistory, but not
Any User Interface Changes (namelist or namelist defaults changes):
No
Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
aux_clm_noresm, prealpha_noresm, aux_blom_noresm
Hashes used for testing:

