### PR TITLE
Fix taxmode for multilev-cplhist in DOCN

### DIFF
--- a/docn/cime_config/stream_definition_docn.xml
+++ b/docn/cime_config/stream_definition_docn.xml
@@ -257,7 +257,7 @@
       <tintalgo>nearest</tintalgo>
     </stream_tintalgo>
     <stream_taxmode>
-      <taxmode>extend</taxmode>
+      <taxmode>cycle</taxmode>
     </stream_taxmode>
     <stream_dtlimit>
       <dtlimit>1.e30</dtlimit>


### PR DESCRIPTION
Change default tax mode from extend to cycle
