### PR TITLE
bugfix for handling unstructured input data with multiple levels

### DIFF
--- a/datm/datm_datamode_cplhist_mod.F90
+++ b/datm/datm_datamode_cplhist_mod.F90
@@ -24,8 +24,6 @@ module datm_datamode_cplhist_mod
   real(r8), pointer :: Sa_tbot(:)           => null()
   real(r8), pointer :: Sa_ptem(:)           => null()
   real(r8), pointer :: Sa_shum(:)           => null()
-  ! TODO: water isotope support
-  !  real(r8), pointer :: Sa_shum_wiso(:,:)    => null() ! water isotopes
   real(r8), pointer :: Sa_dens(:)           => null()
   real(r8), pointer :: Sa_pbot(:)           => null()
   real(r8), pointer :: Sa_pslv(:)           => null()
@@ -38,7 +36,6 @@ module datm_datamode_cplhist_mod
   real(r8), pointer :: Faxa_swndf(:)        => null()
   real(r8), pointer :: Faxa_swvdr(:)        => null()
   real(r8), pointer :: Faxa_swvdf(:)        => null()
-  real(r8), pointer :: Faxa_swnet(:)        => null()
   real(r8), pointer :: Faxa_ndep(:,:)       => null()
 
   character(*), parameter :: nullstr = 'null'
@@ -87,7 +84,6 @@ contains
     call dshr_fldList_add(fldsExport, 'Faxa_swvdr' )
     call dshr_fldList_add(fldsExport, 'Faxa_swndf' )
     call dshr_fldList_add(fldsExport, 'Faxa_swvdf' )
-    call dshr_fldList_add(fldsExport, 'Faxa_swnet' )
     call dshr_fldList_add(fldsExport, 'Faxa_lwdn'  )
     call dshr_fldList_add(fldsExport, 'Faxa_swdn'  )
     if (flds_co2) then
@@ -171,8 +167,6 @@ contains
     call dshr_state_getfldptr(exportState, 'Faxa_swndr' , fldptr1=Faxa_swndr , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_swndf' , fldptr1=Faxa_swndf , rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call dshr_state_getfldptr(exportState, 'Faxa_swnet' , fldptr1=Faxa_swnet , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_lwdn'  , fldptr1=Faxa_lwdn  , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/dlnd/lnd_comp_nuopc.F90
+++ b/dlnd/lnd_comp_nuopc.F90
@@ -26,13 +26,11 @@ module cdeps_dlnd_comp
   use shr_kind_mod      , only : cx=>shr_kind_cx
   use shr_cal_mod       , only : shr_cal_ymd2date
   use shr_log_mod       , only : shr_log_setLogUnit, shr_log_error
-  use dshr_methods_mod  , only : dshr_state_getfldptr, dshr_state_diagnose, chkerr, memcheck
-  use dshr_strdata_mod  , only : shr_strdata_type, shr_strdata_advance, shr_strdata_get_stream_domain
-  use dshr_strdata_mod  , only : shr_strdata_init_from_config
+  use dshr_methods_mod  , only : dshr_state_diagnose, chkerr, memcheck
+  use dshr_strdata_mod  , only : shr_strdata_type, shr_strdata_advance, shr_strdata_init_from_config
   use dshr_mod          , only : dshr_model_initphase, dshr_init, dshr_check_restart_alarm
   use dshr_mod          , only : dshr_state_setscalar, dshr_set_runclock, dshr_log_clock_advance
   use dshr_mod          , only : dshr_restart_read, dshr_restart_write, dshr_mesh_init
-  use dshr_dfield_mod   , only : dfield_type, dshr_dfield_add, dshr_dfield_copy
   use dshr_fldlist_mod  , only : fldlist_type, dshr_fldlist_add, dshr_fldlist_realize
 
   ! Datamode specialized modules
@@ -91,7 +89,6 @@ module cdeps_dlnd_comp
 
   ! linked lists
   type(fldList_type) , pointer :: fldsExport => null()
-  type(dfield_type)  , pointer :: dfields    => null()
 
   ! model mask and model fraction
   real(r8), pointer            :: model_frac(:) => null()
@@ -172,9 +169,6 @@ contains
     integer       :: bcasttmp(4)
     integer       :: ierr       ! error code
     character(len=*) , parameter :: subname=trim(modName)//':(InitializeAdvertise) '
-    character(*)     , parameter :: F00 = "('(" // trim(modName) // ") ',8a)"
-    character(*)     , parameter :: F01 = "('(" // trim(modName) // ") ',a,2x,i8)"
-    character(*)     , parameter :: F02 = "('(" // trim(modName) // ") ',a,l6)"
     !-------------------------------------------------------------------------------
 
     namelist / dlnd_nml / datamode, model_meshfile, model_maskfile, &
@@ -235,14 +229,14 @@ contains
 
     ! write namelist input to standard out
     if (my_task == main_task) then
-       write(logunit,F00)' model_meshfile    = ',trim(model_meshfile)
-       write(logunit,F00)' model_maskfile    = ',trim(model_maskfile)
-       write(logunit,F00)' datamode          = ',datamode
-       write(logunit,F01)' nx_global         = ',nx_global
-       write(logunit,F01)' ny_global         = ',ny_global
-       write(logunit,F00)' restfilm          = ',trim(restfilm)
-       write(logunit,F02)' skip_restart_read = ',skip_restart_read
-       write(logunit,F02)' export_all        = ',export_all
+       write(logunit,'(3a)')    trim(subname),' model_meshfile    = ',trim(model_meshfile)
+       write(logunit,'(3a)')    trim(subname),' model_maskfile    = ',trim(model_maskfile)
+       write(logunit,'(3a)')    trim(subname),' datamode          = ',datamode
+       write(logunit,'(2a,i0)') trim(subname),' nx_global         = ',nx_global
+       write(logunit,'(2a,i0)') trim(subname),' ny_global         = ',ny_global
+       write(logunit,'(3a)')    trim(subname),' restfilm          = ',trim(restfilm)
+       write(logunit,'(2a,l6)') trim(subname),' skip_restart_read = ',skip_restart_read
+       write(logunit,'(2a,l6)') trim(subname),' export_all        = ',export_all
     endif
 
     ! Validate sdat datamode
@@ -458,16 +452,13 @@ contains
     !--------------------
 
     if (first_time) then
-       ! Initialize datamode module pointers AND dfields
+       ! Initialize datamode export state and stream pointers
        select case (trim(datamode))
-       case('glc_forcing_mct')
-          call dlnd_datamode_glc_forcing_init_pointers(exportState, sdat, dfields, model_frac, datamode, logunit, mainproc, rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       case('glc_forcing')
-          call dlnd_datamode_glc_forcing_init_pointers(exportState, sdat, dfields, model_frac, datamode, logunit, mainproc, rc)
+       case('glc_forcing_mct','glc_forcing')
+          call dlnd_datamode_glc_forcing_init_pointers(exportState, sdat, model_frac, datamode, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case('rof_forcing')
-          call dlnd_datamode_rof_forcing_init_pointers(exportState, sdat, dfields, model_frac, logunit, mainproc, rc)
+          call dlnd_datamode_rof_forcing_init_pointers(exportState, sdat, model_frac, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end select
 
@@ -484,20 +475,13 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('dlnd_strdata_advance')
 
-    ! copy all fields from streams to export state as default
-    ! This automatically will update the fields in the export state
-    call ESMF_TraceRegionEnter('dlnd_dfield_copy')
-    call dshr_dfield_copy(dfields, sdat, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TraceRegionExit('dlnd_dfield_copy')
-
-    if (trim(datamode) == 'glc_forcing_mct' .or. trim(datamode) == 'glc_forcing' ) then
-       call dlnd_datamode_glc_forcing_advance(exportState, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    else if (trim(datamode) == 'rof_forcing') then
-       call dlnd_datamode_rof_forcing_advance(exportState, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
+    ! determine data model behavior based on the mode
+    select case (trim(datamode))
+    case('glc_forcing_mct','glc_forcing')
+       call dlnd_datamode_glc_forcing_advance()
+    case('rof_forcing')
+       call dlnd_datamode_rof_forcing_advance()
+    end select
 
     call ESMF_TraceRegionExit('DLND_RUN')
 

--- a/dshr/dshr_dfield_mod.F90
+++ b/dshr/dshr_dfield_mod.F90
@@ -117,7 +117,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     dfield_new%state_data1d = 0.0_r8
     if (mainproc) then
-       write(logunit,'(2a)') trim(subname),' setting pointer for export state '//trim(state_fld)
+       write(logunit,'(3a)') trim(subname),' setting pointer for export state ',trim(state_fld)
     end if
 
   end subroutine dshr_dfield_add_1d
@@ -194,7 +194,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     dfield_new%state_data1d = 0.0_r8
     if (mainproc) then
-       write(logunit,'(2a)') trim(subname),' setting pointer for export state '//trim(state_fld)
+       write(logunit,'(3a)') trim(subname),' setting pointer for export state ',trim(state_fld)
     end if
 
     ! Return array pointer if argument is present
@@ -203,8 +203,8 @@ contains
     ! write output
     if (mainproc) then
        if (found) then
-          write(logunit,'(2a,i0,a,i0)') trim(subname),&
-               ' setting pointer to stream field strm_'//trim(strm_fld)//&
+          write(logunit,'(4a,i0,a,i0)') trim(subname),&
+               ' setting pointer to stream field strm_',trim(strm_fld), &
                ' stream index = ',ns,' field bundle index= ',nf
        end if
        write(logunit,*)
@@ -297,8 +297,8 @@ contains
                 if (trim(strm_flds(nf)) == trim(lfieldnamelist(n))) then
                    dfield_new%fldbun_indices(nf) = n
                    if (mainproc) then
-                      write(logunit,'(2a)') trim(subname),&
-                           ' using stream field strm_'//trim(strm_flds(nf))//' for 2d '//trim(state_fld)
+                      write(logunit,'(5a)') trim(subname), &
+                           ' using stream field strm_',trim(strm_flds(nf)),' for 2d ',trim(state_fld)
                    end if
                 end if
              end do
@@ -314,7 +314,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     dfield_new%state_data2d(:,:) = 0._r8
     if (mainproc) then
-       write(logunit,'(2a)') trim(subname),' setting pointer for export state '//trim(state_fld)
+       write(logunit,'(3a)') trim(subname),' setting pointer for export state ',trim(state_fld)
     end if
 
   end subroutine dshr_dfield_add_2d
@@ -404,8 +404,8 @@ contains
                 if (trim(strm_flds(nf)) == trim(lfieldnamelist(n))) then
                    dfield_new%fldbun_indices(nf) = n
                    if (mainproc) then
-                      write(logunit,'(2a)') trim(subname), &
-                           ' using stream field strm_'//trim(strm_flds(nf))//' for 2d '//trim(state_fld)
+                      write(logunit,'(5a)') trim(subname), &
+                           ' using stream field strm_',trim(strm_flds(nf)),' for 2d ',trim(state_fld)
                    end if
                 end if
              end do
@@ -421,7 +421,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     dfield_new%state_data2d(:,:) = 0._r8
     if (mainproc) then
-       write(logunit,'(2a)') trim(subname),' setting pointer for export state '//trim(state_fld)
+       write(logunit,'(3a)') trim(subname),' setting pointer for export state ',trim(state_fld)
     end if
     state_ptr => dfield_new%state_data2d
 

--- a/dshr/dshr_dfield_mod.F90
+++ b/dshr/dshr_dfield_mod.F90
@@ -117,8 +117,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     dfield_new%state_data1d = 0.0_r8
     if (mainproc) then
-       write(logunit,110)'(dshr_addfield_add) setting pointer for export state '//trim(state_fld)
-110    format(a)
+       write(logunit,'(2a)') trim(subname),' setting pointer for export state '//trim(state_fld)
     end if
 
   end subroutine dshr_dfield_add_1d
@@ -195,8 +194,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     dfield_new%state_data1d = 0.0_r8
     if (mainproc) then
-       write(logunit,110)'(dshr_addfield_add) setting pointer for export state '//trim(state_fld)
-110    format(a)
+       write(logunit,'(2a)') trim(subname),' setting pointer for export state '//trim(state_fld)
     end if
 
     ! Return array pointer if argument is present
@@ -205,9 +203,9 @@ contains
     ! write output
     if (mainproc) then
        if (found) then
-          write(logunit,100)'(dshr_addfield_add) set pointer to stream field strm_'//trim(strm_fld)//&
+          write(logunit,'(2a,i0,a,i0)') trim(subname),&
+               ' setting pointer to stream field strm_'//trim(strm_fld)//&
                ' stream index = ',ns,' field bundle index= ',nf
-100       format(a,i6,2x,a,i6)
        end if
        write(logunit,*)
     end if
@@ -299,8 +297,8 @@ contains
                 if (trim(strm_flds(nf)) == trim(lfieldnamelist(n))) then
                    dfield_new%fldbun_indices(nf) = n
                    if (mainproc) then
-                      write(logunit,*)'(dshr_addfield_add) using stream field strm_'//&
-                           trim(strm_flds(nf))//' for 2d '//trim(state_fld)
+                      write(logunit,'(2a)') trim(subname),&
+                           ' using stream field strm_'//trim(strm_flds(nf))//' for 2d '//trim(state_fld)
                    end if
                 end if
              end do
@@ -316,7 +314,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     dfield_new%state_data2d(:,:) = 0._r8
     if (mainproc) then
-       write(logunit,*)'(dshr_addfield_add) setting pointer for export state '//trim(state_fld)
+       write(logunit,'(2a)') trim(subname),' setting pointer for export state '//trim(state_fld)
     end if
 
   end subroutine dshr_dfield_add_2d
@@ -406,8 +404,8 @@ contains
                 if (trim(strm_flds(nf)) == trim(lfieldnamelist(n))) then
                    dfield_new%fldbun_indices(nf) = n
                    if (mainproc) then
-                      write(logunit,*)'(dshr_addfield_add) using stream field strm_'//&
-                           trim(strm_flds(nf))//' for 2d '//trim(state_fld)
+                      write(logunit,'(2a)') trim(subname), &
+                           ' using stream field strm_'//trim(strm_flds(nf))//' for 2d '//trim(state_fld)
                    end if
                 end if
              end do
@@ -423,7 +421,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     dfield_new%state_data2d(:,:) = 0._r8
     if (mainproc) then
-       write(logunit,*)'(dshr_addfield_add) setting pointer for export state '//trim(state_fld)
+       write(logunit,'(2a)') trim(subname),' setting pointer for export state '//trim(state_fld)
     end if
     state_ptr => dfield_new%state_data2d
 

--- a/streams/dshr_methods_mod.F90
+++ b/streams/dshr_methods_mod.F90
@@ -64,6 +64,12 @@ contains
 
     rc = ESMF_SUCCESS
 
+    ! only one of fldptr1 or fldptr2 can be present
+    if (present(fldptr1) .and. present(fldptr2)) then
+       call shr_log_error(trim(subname)//": both fldptr1 and fldptr2 cannot be present ",rc=rc)
+       return
+    end if
+
     if (present(allowNullReturn)) then
       call ESMF_StateGet(State, itemSearch=trim(fldname), itemCount=itemCount, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/streams/dshr_methods_mod.F90
+++ b/streams/dshr_methods_mod.F90
@@ -14,7 +14,7 @@ module dshr_methods_mod
   use ESMF         , only : ESMF_TraceRegionEnter, ESMF_TraceRegionExit
   use shr_kind_mod , only : r8=>shr_kind_r8, cs=>shr_kind_cs, cl=>shr_kind_cl
   use shr_log_mod  , only : shr_log_error
-  
+
   implicit none
   public
 
@@ -41,6 +41,8 @@ contains
 
   subroutine dshr_state_getfldptr(State, fldname, fldptr1, fldptr2, allowNullReturn, rc)
 
+    use shr_infnan_mod, only: nan => shr_infnan_nan, assignment(=)
+
     ! ----------------------------------------------
     ! Get pointer to a state field
     ! ----------------------------------------------
@@ -50,10 +52,11 @@ contains
     character(len=*) ,          intent(in)              :: fldname
     real(R8)         , pointer, intent(inout), optional :: fldptr1(:)
     real(R8)         , pointer, intent(inout), optional :: fldptr2(:,:)
-    logical          ,          intent(in),optional     :: allowNullReturn
+    logical          ,          intent(in)   , optional :: allowNullReturn
     integer          ,          intent(out)             :: rc
 
     ! local variables
+    integer                     :: ni, nj
     type(ESMF_Field)            :: lfield
     integer                     :: itemCount
     character(len=*), parameter :: subname='(dshr_state_getfldptr)'
@@ -74,7 +77,9 @@ contains
         if (chkerr(rc,__LINE__,u_FILE_u)) return
       else
         ! the call to just returns if it cannot find the field
-        call ESMF_LogWrite(trim(subname)//" Could not find the field: "//trim(fldname)//" just returning", ESMF_LOGMSG_INFO)
+         call ESMF_LogWrite(trim(subname)//" Could not find the field: "//trim(fldname)//&
+              " just returning", ESMF_LOGMSG_INFO)
+        return
       end if
     else
       call ESMF_StateGet(State, itemName=trim(fldname), field=lfield, rc=rc)
@@ -82,6 +87,19 @@ contains
 
       call dshr_field_getfldptr(lfield, fldptr1=fldptr1, fldptr2=fldptr2, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    end if
+
+    ! Initialize pointer value
+    if (present(fldptr1)) then
+       do ni = 1,size(fldptr1)
+          fldptr1(ni) = nan
+       end do
+    else if (present(fldptr2)) then
+       do nj = 1,size(fldptr2, dim=2)
+          do ni = 1,size(fldptr2, dim=1)
+             fldptr2(ni,nj) = nan
+          end do
+       end do
     end if
 
   end subroutine dshr_state_getfldptr

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -815,8 +815,9 @@ contains
        write(sdat%logunit,'(2a,i0,a,i0)') subname, &
             'Stream: ',stream_index,' stream_nlev = ',stream_nlev
        if (stream_nlev /= 1) then
-          write(sdat%logunit,'(3a)') subname,&
-               'Stream: ',stream_index,' stream vertical levels = ',sdat%pstrm(stream_index)%stream_vlevs
+          write(sdat%logunit,'(2a,i0,a)') subname, &
+               'Stream: ',stream_index,' has following vertical levels'
+          write(sdat%logunit,*) sdat%pstrm(stream_index)%stream_vlevs
        end if
     end if
 
@@ -2192,6 +2193,9 @@ contains
     do n = 1, ndims
        rcode = pio_inq_dimlen(pioid, dimids(n), dimlens(n))
     end do
+
+    ! Determine if there is a time dimension
+    rcode = pio_inq_dimname(pioid, dimids(ndims), dimname)
 
     ! determine compdof for stream
     call ESMF_MeshGet(per_stream%stream_mesh, elementdistGrid=distGrid, rc=rc)

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -2170,7 +2170,7 @@ contains
        rcode = pio_inq_dimname(pioid, dimids(ndims), dimname)
        if (stream_nlev > 1 .and. (trim(dimname) == 'time' .or. trim(dimname) == 'nt')) then
           if (mainproc) then
-             write(logout,'(2a,2s,3(i0,2x),a)') trim(subname), &
+             write(logout,'(2a,2x,3(i0,2x),a)') trim(subname), &
                   ' setting iodesc for 4d: '//trim(fldname)//' with dimlens(1), dimlens(2),dimlens(3) = ',&
                   dimlens(1),dimlens(2),dimlens(3), &
                   ' where dimlens(3) is a vertical dimension and dimlens(4) is a time dimension '

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -45,7 +45,6 @@ module dshr_strdata_mod
   use dshr_methods_mod , only : dshr_fldbun_getfldptr, dshr_fldbun_getfieldN, dshr_fldbun_fldchk, chkerr
   use dshr_methods_mod , only : dshr_fldbun_diagnose, dshr_fldbun_regrid, dshr_field_getfldptr
   use shr_sys_mod      , only : shr_sys_abort
-
   use pio              , only : file_desc_t, iosystem_desc_t, io_desc_t, var_desc_t
   use pio              , only : pio_openfile, pio_closefile, pio_nowrite
   use pio              , only : pio_seterrorhandling, pio_initdecomp, pio_freedecomp
@@ -2197,81 +2196,137 @@ contains
   end subroutine shr_strdata_set_stream_iodesc
 
   !===============================================================================
-  subroutine shr_strdata_get_stream_pointer_1d(sdat, strm_fld, strm_ptr, rc)
+  subroutine shr_strdata_get_stream_pointer_1d(sdat, strm_fld, strm_ptr, &
+       rc, requirePointer, errmsg)
+
+    use shr_infnan_mod, only: nan => shr_infnan_nan, assignment(=)
 
     ! Set a pointer, strm_ptr, for field, strm_fld, into sdat fldbun_model field bundle
 
     ! input/output variables
-    type(shr_strdata_type) , intent(in)    :: sdat
-    character(len=*)       , intent(in)    :: strm_fld
-    real(r8)               , pointer       :: strm_ptr(:)
-    integer                , intent(out)   :: rc
+    type(shr_strdata_type)     , intent(in)    :: sdat
+    character(len=*)           , intent(in)    :: strm_fld
+    real(r8)                   , pointer       :: strm_ptr(:)
+    integer                    , intent(out)   :: rc
+    logical,          optional , intent(in)    :: requirePointer
+    character(len=*), optional , intent(in)    :: errmsg
 
     ! local variables
-    integer :: ns, nf
+    integer :: ns, nf, ni
     logical :: found
-    character(len=*), parameter :: subname='(shr_strdata_get_stream_pointer_1d)'
+    character(len=*), parameter :: subname='(shr_strdata_get_stream_pointer_1d) '
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
 
+    found = .false.
+
     ! loop over all input streams and determine if the strm_fld is in the field bundle of the target stream
-    do ns = 1, shr_strdata_get_stream_count(sdat)
-       found = .false.
-       ! Check if requested stream field is read in - and if it is then point into the stream field bundle
-       do nf = 1,size(sdat%pstrm(ns)%fldlist_model)
+    stream_loop: do ns = 1, shr_strdata_get_stream_count(sdat)
+       ! Check if requested stream field is read in - and if it is set pointer
+       fld_loop: do nf = 1,size(sdat%pstrm(ns)%fldlist_model)
           if (trim(strm_fld) == trim(sdat%pstrm(ns)%fldlist_model(nf))) then
              call dshr_fldbun_getfldptr(sdat%pstrm(ns)%fldbun_model, trim(sdat%pstrm(ns)%fldlist_model(nf)), &
                   fldptr1=strm_ptr, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
-             if (mainproc) then
-                write(logout,'(2a)') trim(subname),' strm_ptr is allocated for stream field strm_'//trim(strm_fld)
-             end if
              found = .true.
-             exit
+             exit stream_loop
           end if
+       end do fld_loop
+    end do stream_loop
+
+    if (found) then
+       ! If pointer found, preset value
+       if (mainproc) then
+          write(logout,'(2a)') trim(subname), &
+               ' strm_ptr is allocated and preset to nan for stream field strm_'//trim(strm_fld)
+       end if
+       do ni = 1,size(strm_ptr)
+          strm_ptr(ni) = nan
        end do
-       if (found) exit
-    end do
+    else
+       ! What to do if fldbun pointer is not found
+       if (present(requirePointer)) then
+          if (requirePointer) then
+             if (present(errmsg)) then
+                if (mainproc) then
+                   write(logout,'(2a)') trim(subname), trim(errmsg)
+                end if
+             end if
+             call shr_log_error(subName//"ERROR: pointer not found for "//trim(strm_fld), rc=rc)
+             return
+          end if
+       end if
+    end if
+
   end subroutine shr_strdata_get_stream_pointer_1d
 
   !===============================================================================
-  subroutine shr_strdata_get_stream_pointer_2d(sdat, strm_fld, strm_ptr, rc)
+  subroutine shr_strdata_get_stream_pointer_2d(sdat, strm_fld, strm_ptr, &
+       rc, requirePointer, errmsg)
+
+    use shr_infnan_mod, only: nan => shr_infnan_nan, assignment(=)
 
     ! Set a pointer, strm_ptr, for field, strm_fld, into sdat fldbun_model field bundle
 
     ! input/output variables
-    type(shr_strdata_type) , intent(in)    :: sdat
-    character(len=*)       , intent(in)    :: strm_fld
-    real(r8)               , pointer       :: strm_ptr(:,:)
-    integer                , intent(out)   :: rc
+    type(shr_strdata_type)     , intent(in)    :: sdat
+    character(len=*)           , intent(in)    :: strm_fld
+    real(r8)                   , pointer       :: strm_ptr(:,:)
+    integer                    , intent(out)   :: rc
+    logical,          optional , intent(in)    :: requirePointer
+    character(len=*), optional , intent(in)    :: errmsg
 
     ! local variables
-    integer :: ns, nf
+    integer :: ns, nf, ni, nj
     logical :: found
-    character(len=*), parameter :: subname='(shr_strdata_get_stream_pointer_2d)'
+    character(len=*), parameter :: subname='(shr_strdata_get_stream_pointer_2d) '
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
 
+    found = .false.
+
     ! loop over all input streams and determine if the strm_fld is in the field bundle of the target stream
-    do ns = 1, shr_strdata_get_stream_count(sdat)
-       found = .false.
-       ! Check if requested stream field is read in - and if it is then point into the stream field bundle
-       do nf = 1,size(sdat%pstrm(ns)%fldlist_model)
+    stream_loop: do ns = 1, shr_strdata_get_stream_count(sdat)
+       ! Check if requested stream field is read in - and if it is set pointer
+       fld_loop: do nf = 1,size(sdat%pstrm(ns)%fldlist_model)
           if (trim(strm_fld) == trim(sdat%pstrm(ns)%fldlist_model(nf))) then
              call dshr_fldbun_getfldptr(sdat%pstrm(ns)%fldbun_model, trim(sdat%pstrm(ns)%fldlist_model(nf)), &
                   fldptr2=strm_ptr, rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
-             if (mainproc) then
-                write(logout,'(2a)') trim(subname),' strm_ptr is allocated for stream field strm_'//trim(strm_fld)
-             end if
              found = .true.
-             exit
+             exit stream_loop
           end if
+       end do fld_loop
+    end do stream_loop
+
+    if (found) then
+       ! If pointer found, preset value
+       if (mainproc) then
+          write(logout,'(2a)') trim(subname), &
+               ' strm_ptr is allocated and preset to nan for stream field strm_'//trim(strm_fld)
+       end if
+       do nj = 1,size(strm_ptr, dim=2)
+          do ni = 1,size(strm_ptr, dim=1)
+             strm_ptr(ni,nj) = nan
+          end do
        end do
-       if (found) exit
-    end do
+    else
+       ! What to do if fldbun pointer is not found
+       if (present(requirePointer)) then
+          if (requirePointer) then
+             if (present(errmsg)) then
+                if (mainproc) then
+                   write(logout,'(2a)') trim(subname),trim(errmsg)
+                end if
+             end if
+             call shr_log_error(subName//"ERROR: pointer not found for "//trim(strm_fld), rc=rc)
+             return
+          end if
+       end if
+    end if
+
   end subroutine shr_strdata_get_stream_pointer_2d
 
 end module dshr_strdata_mod

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -2128,7 +2128,7 @@ contains
                   per_stream%stream_pio_iodesc)
           else
              write(6,*)'ERROR: dimlens= ',dimlens
-             call shr_log_error(trim(subname)//' the third dimension of a 3d field must be either time or a vertical level')
+             call shr_log_error(trim(subname)//' the third dimension of a 3d field must be either time or a vertical level', rc=rc)
              return
           end if
        end if
@@ -2147,13 +2147,13 @@ contains
                per_stream%stream_pio_iodesc)
        else
           write(6,*)'ERROR: dimlens= ',dimlens
-          call shr_log_error(trim(subname)//' dimlens = 4 assumes a time dimension and a vertical dimension')
+          call shr_log_error(trim(subname)//' dimlens = 4 assumes a time dimension and a vertical dimension', rc=rc)
           return
        end if
 
     else
        write(6,*)'ERROR: dimlens= ',dimlens
-       call shr_log_error(trim(subname)//' only ndims of 2 and 3 and 4 are currently supported')
+       call shr_log_error(trim(subname)//' only ndims of 2 and 3 and 4 are currently supported', rc=rc)
        return
     end if
 

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -815,9 +815,9 @@ contains
        write(sdat%logunit,'(2a,i0,a,i0)') subname, &
             'Stream: ',stream_index,' stream_nlev = ',stream_nlev
        if (stream_nlev /= 1) then
-          write(sdat%logunit,'(2a,i0,a)') subname, &
-               'Stream: ',stream_index,' has following vertical levels'
-          write(sdat%logunit,*) sdat%pstrm(stream_index)%stream_vlevs
+          write(sdat%logunit,'(2a,i0,a)') subname,&
+               'Stream: ',stream_index,' has following vertical levels '
+          write(sdat%logunit,*)sdat%pstrm(stream_index)%stream_vlevs
        end if
     end if
 
@@ -1293,7 +1293,7 @@ contains
                   algo=trim(sdat%stream(ns)%tinterpalgo), rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
              if (debug_level > 0 .and. sdat%mainproc) then
-                write(sdat%logunit,'(2a,i0,2(f10.5,2x))') &
+                write(sdat%logunit,'(2a,i0,2(2x,f10.5))') &
                      subname,' non-cosz-interp stream, flb, fub= ',ns,flb,fub
                 write(sdat%logunit,'(a)') '------------------------------------------------------'
              endif
@@ -1498,25 +1498,23 @@ contains
 
     ! write time bounds info
     if (debug_level > 0 .and. sdat%mainproc) then
-       if (debug_level > 0) then
-          write(sdat%logunit,'(2a,i0,a,l7,a,l7)') subname, &
-               'Stream: ',ns,&
-               ' find_bounds = ',find_bounds,' newdata is = ',newdata
-          write(sdat%logunit,'(2a,i0,a,4(2x,i0))') subname, &
-               'Stream: ',ns,&
-               ' oDateLB, OSecLb, oDateUB, OsecUB =  ',&
-               oDateLB, OSecLb, oDateUB, OsecUB
-          write(sdat%logunit,'(2a,i0,a,2x,3(f13.6,2x),l4)') subname, &
-               'Stream: ',ns,&
-               ' rdateLB,rdateM,rdateUB = ',&
-               rdateLB, rdateM, rdateUB
-          write(sdat%logunit,'(2a,i0,a,6(i0,2x))') subname, &
-               'Stream: ',ns,&
-               ' lbymd,lbsec,mdate,msec,ubymd,ubsec = ',&
-               sdat%pstrm(ns)%ymdLB, sdat%pstrm(ns)%todLB, &
-               mdate, msec, &
-               sdat%pstrm(ns)%ymdUB, sdat%pstrm(ns)%todUB
-       end if
+       write(sdat%logunit,'(2a,i0,a,l7,a,l7)') subname, &
+            'Stream: ',ns,&
+            ' find_bounds = ',find_bounds,' newdata is = ',newdata
+       write(sdat%logunit,'(2a,i0,a,4(2x,i0))') subname, &
+            'Stream: ',ns,&
+            ' oDateLB, OSecLb, oDateUB, OsecUB =  ',&
+            oDateLB, OSecLb, oDateUB, OsecUB
+       write(sdat%logunit,'(2a,i0,a,2x,3(f13.6,2x))') subname, &
+            'Stream: ',ns,&
+            ' rdateLB,rdateM,rdateUB = ',&
+            rdateLB, rdateM, rdateUB
+       write(sdat%logunit,'(2a,i0,a,6(i0,2x))') subname, &
+            'Stream: ',ns,&
+            ' lbymd,lbsec,mdate,msec,ubymd,ubsec = ',&
+            sdat%pstrm(ns)%ymdLB, sdat%pstrm(ns)%todLB, &
+            mdate, msec, &
+            sdat%pstrm(ns)%ymdUB, sdat%pstrm(ns)%todUB
     end if
 
     ! if newdata, determine if do a copy or read in new lower bound data
@@ -1831,7 +1829,7 @@ contains
              if (handlefill) then
                 ! Single point streams are not allowed to have missing values
                 if (stream%mapalgo == 'none' .and. any(data_real2d == fillvalue_r4)) then
-                   write(errmsg,'(2a)')' ERROR: _Fillvalue found in stream input variable: '//&
+                   write(errmsg,'(2a)')' ERROR: _Fillvalue found in stream input variable: ',&
                         trim(per_stream%fldlist_stream(nf))
                    if (sdat%mainproc) then
                       write(sdat%logunit,'(2a)') subname,trim(errmsg)
@@ -2051,7 +2049,7 @@ contains
 
        ! get lon and lat of stream u and v fields
        lsize = size(dataptr1d)
-       allocate(dataptr(lsize))
+       allocate(dataptr(lsize), stat=istat)
        if ( istat /= 0 ) then
           call shr_log_error(subName//'allocation error of dataptr with size '// &
                toString(lsize), rc=rc)
@@ -2217,12 +2215,15 @@ contains
           return
        end if
        ! Assume that first 2 dimensions correspond to the compdof
+       rcode = pio_inq_dimname(pioid, dimids(ndims), dimname)
        if (trim(dimname) == 'time' .or. trim(dimname) == 'nt') then
           if (ndims == 3) then
              ! second dimension is lev and third dimension is time
+             ! this would then corresond to an unstructured grid with just ncol
              gsize2d = dimlens(1)
           else if (ndims == 4) then
              ! third dimension is lev and fourth dimension is time
+             ! first two dimensions are lon,lat
              gsize2d = dimlens(1)*dimlens(2)
           else
              call shr_log_error(subname//' only ndims of 3 and 4 '//&

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -2032,9 +2032,9 @@ contains
              gsize2d = dimlens(1)*dimlens(2)
           else
              write(6,*)'ERROR: dimlens= ',dimlens
-             call shr_log_error(trim(subname)//' only ndims of 3 and 4 &
-                  total dimensions are currently supported for multiple level fields &
-                  with a time dimension', rc=rc)
+             call shr_log_error(trim(subname)//' only ndims of 3 and 4 '//&
+                  ' total dimensions are currently supported for multiple level fields '// &
+                  ' with a time dimension', rc=rc)
              return
           end if
        else
@@ -2046,9 +2046,9 @@ contains
              gsize2d = dimlens(1)*dimlens(2)
           else
              write(6,*)'ERROR: dimlens= ',dimlens
-             call shr_log_error(trim(subname)//' only ndims of 2 and 3 &
-                  total dimensions are currently supported for multiple level fields &
-                  without a time dimension', rc=rc)
+             call shr_log_error(trim(subname)//' only ndims of 2 and 3 '// &
+                  ' total dimensions are currently supported for multiple level fields '// &
+                  ' without a time dimension', rc=rc)
              return
           end if
        end if

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -1784,11 +1784,13 @@ contains
        else if (pio_iovartype == PIO_SHORT) then
           rcode = pio_get_att(pioid, varid, "scale_factor", scale_factor)
           if(rcode /= PIO_NOERR) then
+             rc = rcode
              call shr_log_error('DATATYPE PIO_SHORT requires attributes scale_factor', rc=rc)
              return
           endif
           rcode = pio_get_att(pioid, varid, "add_offset", add_offset)
           if(rcode /= PIO_NOERR) then
+             rc = rcode
              call shr_log_error('DATATYPE PIO_SHORT requires attributes add_offset', rc=rc)
              return
           endif
@@ -1817,6 +1819,7 @@ contains
                 rcode = pio_get_var(pioid, varid,start=(/1,1,1,nt/),count=(/1,1,1,1/), ival=data_real2d)
              end if
              if ( rcode /= PIO_NOERR ) then
+                rc = rcode
                 call shr_log_error(' ERROR: reading in variable: '// trim(per_stream%fldlist_stream(nf)), rc=rc)
                 return
              end if
@@ -1854,6 +1857,7 @@ contains
                 rcode = pio_get_var(pioid, varid,start=(/1,1,nt/),count=(/1,1,1/), ival=data_real1d)
              endif
              if ( rcode /= PIO_NOERR ) then
+                rc = rcode
                 call shr_log_error(' ERROR: reading in variable: '// trim(per_stream%fldlist_stream(nf)), rc=rc)
                 return
              end if
@@ -1891,6 +1895,7 @@ contains
                 rcode = pio_get_var(pioid, varid,start=(/1,1,1,nt/), count=(/1,1,1,1/), ival=data_dbl2d)
              end if
              if ( rcode /= PIO_NOERR ) then
+                rc = rcode
                 call shr_log_error(' ERROR: reading in 2d double variable: '// trim(per_stream%fldlist_stream(nf)), rc=rc)
                 return
              end if
@@ -1924,6 +1929,7 @@ contains
                 rcode = pio_get_var(pioid, varid,start=(/1,1,nt/), count=(/1,1,1/), ival=data_dbl1d)
              endif
              if ( rcode /= PIO_NOERR ) then
+                rc = rcode
                 call shr_log_error(' ERROR: reading in variable: '// trim(per_stream%fldlist_stream(nf)), rc=rc)
                 return
              end if
@@ -1959,6 +1965,7 @@ contains
                 rcode = pio_get_var(pioid, varid,start=(/1,1,1,nt/), count=(/1,1,1,1/), ival=data_short2d)
              end if
              if ( rcode /= PIO_NOERR ) then
+                rc = rcode
                 call shr_log_error(' ERROR: reading in 2d short variable: '// trim(per_stream%fldlist_stream(nf)), rc=rc)
                 return
              end if
@@ -1986,6 +1993,7 @@ contains
                 rcode = pio_get_var(pioid, varid,start=(/1,1,nt/),count=(/1,1,1/), ival=data_short1d)
              endif
              if ( rcode /= PIO_NOERR ) then
+                rc = rcode
                 call shr_log_error(' ERROR: reading in variable: '// trim(per_stream%fldlist_stream(nf)), rc=rc)
                 return
              end if

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -368,7 +368,7 @@ contains
     nstrms = tmp(1)
 
     if (.not. isroot_task) then
-       allocate(streamdat(nstrms), stat=istat)
+       allocate(streamdat(nstrms))
     endif
 
     ! Set the logunit and mainproc attributes for each stream

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -918,7 +918,8 @@ contains
     if (cycle) then
        dYear  = yrFirst + modulo(mYear-yrAlign+(2*nYears),nYears)   ! current data year
        if(debug_level>0 .and. strm%mainproc) then
-          write(strm%logunit,'(2a,4(i0,2x))') subname, ' dyear, yrfirst, myear, yralign, nyears = ', &
+          write(strm%logunit,'(2a,5(i0,2x))') subname, &
+               ' dyear, yrfirst, myear, yralign, nyears = ', &
                dyear, yrfirst, myear, yralign, nyears
        endif
     else
@@ -937,7 +938,7 @@ contains
     if (debug_level>0 .and. strm%mainproc) then
        write(strm%logunit,'(2a,3(i0,2x),f20.4)') subname, &
             ' mYear,dYear,dDateIn,rDateIn  = ',mYear,dYear,dDateIn,rDateIn
-       write(strm%logunit,'(a,4(i0,2x))') subname, &
+       write(strm%logunit,'(2a,4(i0,2x))') subname, &
             ' yrFirst,yrLast,yrAlign,nYears= ',yrFirst,yrLast,yrAlign,nYears
     endif
 
@@ -1433,7 +1434,7 @@ contains
           din = strm%file(k)%date(n)
           sin = strm%file(k)%secs(n)
           if (debug_level > 5 .and. strm%mainproc) then
-             write(strm%logunit,'(2a,4(i0,2x))') subname,&
+             write(strm%logunit,'(2a,5(i0,2x))') subname,&
                   ' before shr_cal_advDateInt: offset,n,k,strm%file(k)%date(n),strm%file(k)%sec(n) = ',&
              offin,n,k,strm%file(k)%date(n),strm%file(k)%secs(n)
           end if
@@ -2104,8 +2105,8 @@ contains
                    rsfname = streams(k)%file(n)%name(index(streams(k)%file(n)%name, '/',.true.):)
                    if (trim(rfname) /= trim(rsfname)) then
                       if (streams(k)%mainproc) then
-                         write(streams(k)%logunit,'(2a)') subname,trim(rfname), '<>', trim(rsfname)
-                         write(streams(k)%logunit,'(2a)') subname,' fname = '//trim(fname)
+                         write(streams(k)%logunit,'(4a)') subname,trim(rfname), '<>', trim(rsfname)
+                         write(streams(k)%logunit,'(3a)') subname,' fname = ',trim(fname)
                          write(streams(k)%logunit,'(2a,i0,2x,i0,2x,a)') subname,' k,n,streams(k)%file(n)%name = ',&
                               k,n,trim(streams(k)%file(n)%name)
                       end if


### PR DESCRIPTION
### Description of changes
This fixes #25 

### Specific notes
This PR also does the following:
- new error checking for most allocations
- cleanup of stdout formatting
- replacement of` character(*) with character(len=*)`
- introduction  `logunit `and `mainproc` in shr_strdata_type and both `logunit` and `mainproc` in shr_stream_streamType. This is needed since the inline interface was not always writing all log output consistently.
- new expanded API for setting stream pointers with optional arguments in `dshr_strdata_mod.F90` for
shr_strdata_get_stream_pointer_1d and shr_strdata_get_stream_pointer_2d
  
```
 subroutine shr_strdata_get_stream_pointer_1d(sdat, strm_fld, strm_ptr, rc, requirePointer, errmsg) 
    type(shr_strdata_type)     , intent(in)    :: sdat
    character(len=*)           , intent(in)    :: strm_fld
    real(r8)                   , pointer       :: strm_ptr(:)
    integer                    , intent(out)   :: rc
    logical,          optional , intent(in)    :: requirePointer
    character(len=*), optional , intent(in)    :: errmsg
```
and
```
 subroutine shr_strdata_get_stream_pointer_2d(sdat, strm_fld, strm_ptr, rc, requirePointer, errmsg) 
    type(shr_strdata_type)     , intent(in)    :: sdat
    character(len=*)           , intent(in)    :: strm_fld
    real(r8)                   , pointer       :: strm_ptr(:,:)
    integer                    , intent(out)   :: rc
    logical,          optional , intent(in)    :: requirePointer
    character(len=*), optional , intent(in)    :: errmsg
```
If requirePointer is not provided - then if the pointer is not round the subroutine returns without an error. If requirePointer is an argument and is true, than normally an errmsg is provided that with it describes why the pointer is required. Also - now if the pointer is required and is found - then the pointer is initialized to NaN.
The new setting of NaNs in the stream and state pointers resulted in the following additional changes that needed to be brought in:
- refactored dlnd code to remove presence of present nans in stream pointers
- fixed problem in drof that came up due to presence of presence of nans
- fixed problem in datm/cplhist that cam up due to presence of nans

Contributors other than yourself, if any: None

CDEPS Issues Fixed: #25 

Are there dependencies on other component PRs: None

Are changes expected to change answers (bfb, different to roundoff, more substantial): bfb

Any User Interface Changes (namelist or namelist defaults changes): None

Testing performed: 
- Correctly reading in nudging data at ne16pg3 with 58 vertical levels.
- aux_clm_noresm compared to ctsm5.4.002_noresm_v1 passed
- aux_blom_noresm compared to noresm3_0_beta09 passed
- aux_cam_noresm compared to noresm3_0_beta09 passed
- noresm_prealpha compared to noresm3_0_beta09 passed

Hashes used for testing:
noresm3_0_beta09 with this PR

