### PR TITLE
new datm optional streams for ndep, presaero, co2 and o3

### DIFF
--- a/.github/workflows/extbuild.yml
+++ b/.github/workflows/extbuild.yml
@@ -19,8 +19,8 @@ jobs:
       CPPFLAGS: "-I/usr/include -I/usr/local/include "
       LDFLAGS: "-L/usr/lib/x86_64-linux-gnu "
       # Versions of all dependencies can be updated here - these match tag names in the github repo
-      ESMF_VERSION: v8.6.1
-      ParallelIO_VERSION: pio2_6_2
+      ESMF_VERSION: v8.9.0
+      ParallelIO_VERSION: pio2_6_6
     steps:
       - id: checkout-CDEPS
         uses: actions/checkout@v4
@@ -39,8 +39,8 @@ jobs:
         id: cache-PARALLELIO
         uses: actions/cache@v4
         with:
-          path: ${GITHUB_WORKSPACE}/pio
-          key: ${{ runner.os }}-${{ env.ParallelIO_VERSION }}-parallelio2
+          path: /home/runner/work/CDEPS/CDEPS/pio
+          key: ${{ runner.os }}-${{ env.ParallelIO_VERSION }}-parallelio
       - name: Build ParallelIO
         if: steps.cache-PARALLELIO.outputs.cache-hit != 'true'
         uses: NCAR/ParallelIO/.github/actions/parallelio_cmake@9390e30e29d4ebbfbef0fc72162cacd9e8f25e4e
@@ -49,7 +49,7 @@ jobs:
           enable_fortran: True
           install_prefix: ${GITHUB_WORKSPACE}/pio
       - name: Install ESMF
-        uses: esmf-org/install-esmf-action@v1
+        uses: esmf-org/install-esmf-action@v1.0.2
         env:
           ESMF_COMPILER: gfortran
           ESMF_BOPT: g

--- a/datm/CMakeLists.txt
+++ b/datm/CMakeLists.txt
@@ -6,7 +6,11 @@ set(SRCFILES atm_comp_nuopc.F90
              datm_datamode_jra_mod.F90
              datm_datamode_gefs_mod.F90
              datm_datamode_era5_mod.F90
-             datm_datamode_simple_mod.F90)
+             datm_datamode_simple_mod.F90
+             datm_pres_aero_mod.F90
+             datm_pres_co2_mod.F90
+             datm_pres_ndep_mod.F90
+             datm_pres_o3_mod.F90)
 
 
 foreach(FILE ${SRCFILES})

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -155,9 +155,9 @@ module cdeps_datm_comp
   logical                      :: diagnose_data = .true.
   integer          , parameter :: main_task   = 0                   ! task number of main task
 #ifdef CESMCOUPLED
-  character(*)     , parameter :: modName       = "(atm_comp_nuopc)"
+  character(*)     , parameter :: modName = "(atm_comp_nuopc)"
 #else
-  character(*)     , parameter :: modName       = "(cdeps_datm_comp)"
+  character(*)     , parameter :: modName = "(cdeps_datm_comp)"
 #endif
 
   character(*), parameter :: u_FILE_u = &
@@ -172,7 +172,7 @@ contains
     integer, intent(out) :: rc
 
     ! local variables
-    character(len=*),parameter  :: subname=trim(modName)//':(SetServices) '
+    character(len=*),parameter  :: subname = modName//':(SetServices) '
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -228,10 +228,10 @@ contains
     integer           :: bcasttmp(10)
     character(CL)     :: nextsw_cday_calc
     type(ESMF_VM)     :: vm
-    character(len=*),parameter :: subname=trim(modName) // ':(InitializeAdvertise) '
-    character(*)    ,parameter :: F00 = "('(" // trim(modName) // ") ',8a)"
-    character(*)    ,parameter :: F01 = "('(" // trim(modName) // ") ',a,2x,i8)"
-    character(*)    ,parameter :: F02 = "('(" // trim(modName) // ") ',a,l6)"
+    character(len=*),parameter :: subname = modName // ':(InitializeAdvertise) '
+    character(*)    ,parameter :: F00 = "('(" // modName // ") ',8a)"
+    character(*)    ,parameter :: F01 = "('(" // modName // ") ',a,2x,i8)"
+    character(*)    ,parameter :: F02 = "('(" // modName // ") ',a,l6)"
     !-------------------------------------------------------------------------------
 
     namelist / datm_nml / &
@@ -386,7 +386,7 @@ contains
        return
     endif
 
-    ! Advertise fields that are not datamode specific
+    ! Advertise fields that ARE NOT datamode specific
     if (flds_co2) then
        call datm_pres_co2_advertise(fldsExport, datamode)
     end if
@@ -400,7 +400,7 @@ contains
        call datm_pres_aero_advertise(fldsExport)
     end if
 
-    ! Advertise fields that are not datamode specific
+    ! Advertise fields that ARE datamode specific
     select case (trim(datamode))
     case ('CORE2_NYF', 'CORE2_IAF')
        call datm_datamode_core2_advertise(exportState, fldsExport, flds_scalar_name, rc)
@@ -455,7 +455,7 @@ contains
     real(R8)                :: orbObliqr     ! orb obliquity (radians)
     logical                 :: isPresent, isSet
     real(R8)                :: dayofYear
-    character(len=*), parameter :: subname=trim(modName)//':(InitializeRealize) '
+    character(len=*), parameter :: subname = modName//':(InitializeRealize) '
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -555,7 +555,7 @@ contains
     real(R8)                :: orbLambm0     ! orb mean long of perhelion (radians)
     real(R8)                :: orbObliqr     ! orb obliquity (radians)
     real(R8)                :: dayofYear
-    character(len=*),parameter  :: subname=trim(modName)//':(ModelAdvance) '
+    character(len=*),parameter  :: subname = modName//':(ModelAdvance) '
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -844,7 +844,7 @@ contains
       call ESMF_StateGet(exportState, itemNameList=lfieldnames, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
       do n = 1, fieldCount
-         call ESMF_LogWrite(trim(subname)//': field name = '//trim(lfieldnames(n)), ESMF_LOGMSG_INFO)
+         call ESMF_LogWrite(subname//': field name = '//trim(lfieldnames(n)), ESMF_LOGMSG_INFO)
          call ESMF_StateGet(exportState, itemName=trim(lfieldnames(n)), field=lfield, rc=rc)
          if (chkerr(rc,__LINE__,u_FILE_u)) return
          call ESMF_FieldGet(lfield, rank=rank, rc=rc)

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -729,25 +729,19 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('datm_strdata_advance')
 
-    ! update export state co2 if appropriate
+    ! update export state if appropriate
     if (flds_co2) then
        call datm_pres_co2_advance()
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
-
-    ! update export state o3 if appropriate
     if (flds_preso3) then
        call datm_pres_o3_advance()
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
-
-    ! ungridded dimension output - update export state nitrogen deposition if appropriate
     if (flds_presndep) then
        call datm_pres_ndep_advance()
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
-
-    ! ungridded dimension output - upate prescribed aerosol if appropriate
     if (flds_presaero) then
        call datm_pres_aero_advance()
        if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -729,7 +729,7 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('datm_strdata_advance')
 
-    ! update export state if appropriate
+    ! Update export state for non data-mode specific fields
     if (flds_co2) then
        call datm_pres_co2_advance()
        if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -155,12 +155,12 @@ module cdeps_datm_comp
   logical                      :: diagnose_data = .true.
   integer          , parameter :: main_task   = 0                   ! task number of main task
 #ifdef CESMCOUPLED
-  character(*)     , parameter :: modName = "(atm_comp_nuopc)"
+  character(len=*) , parameter :: modName = "(atm_comp_nuopc)"
 #else
-  character(*)     , parameter :: modName = "(cdeps_datm_comp)"
+  character(len=*) , parameter :: modName = "(cdeps_datm_comp)"
 #endif
 
-  character(*), parameter :: u_FILE_u = &
+  character(len=*) , parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================

--- a/datm/atm_comp_nuopc.F90
+++ b/datm/atm_comp_nuopc.F90
@@ -68,6 +68,22 @@ module cdeps_datm_comp
   use datm_datamode_simple_mod  , only : datm_datamode_simple_init_pointers
   use datm_datamode_simple_mod  , only : datm_datamode_simple_advance
 
+  use datm_pres_ndep_mod        , only : datm_pres_ndep_advertise
+  use datm_pres_ndep_mod        , only : datm_pres_ndep_init_pointers
+  use datm_pres_ndep_mod        , only : datm_pres_ndep_advance
+
+  use datm_pres_aero_mod        , only : datm_pres_aero_advertise
+  use datm_pres_aero_mod        , only : datm_pres_aero_init_pointers
+  use datm_pres_aero_mod        , only : datm_pres_aero_advance
+
+  use datm_pres_o3_mod          , only : datm_pres_o3_advertise
+  use datm_pres_o3_mod          , only : datm_pres_o3_init_pointers
+  use datm_pres_o3_mod          , only : datm_pres_o3_advance
+
+  use datm_pres_co2_mod         , only : datm_pres_co2_advertise
+  use datm_pres_co2_mod         , only : datm_pres_co2_init_pointers
+  use datm_pres_co2_mod         , only : datm_pres_co2_advance
+
   implicit none
   private ! except
 
@@ -370,23 +386,33 @@ contains
        return
     endif
 
-    ! Advertise datm fields
+    ! Advertise fields that are not datamode specific
+    if (flds_co2) then
+       call datm_pres_co2_advertise(fldsExport, datamode)
+    end if
+    if (flds_preso3) then
+       call datm_pres_o3_advertise(fldsExport)
+    end if
+    if (flds_presndep) then
+       call datm_pres_ndep_advertise(fldsExport)
+    end if
+    if (flds_presaero) then
+       call datm_pres_aero_advertise(fldsExport)
+    end if
+
+    ! Advertise fields that are not datamode specific
     select case (trim(datamode))
     case ('CORE2_NYF', 'CORE2_IAF')
-       call datm_datamode_core2_advertise(exportState, fldsExport, flds_scalar_name, &
-            flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
+       call datm_datamode_core2_advertise(exportState, fldsExport, flds_scalar_name, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('CORE_IAF_JRA', 'CORE_RYF6162_JRA', 'CORE_RYF8485_JRA', 'CORE_RYF9091_JRA', 'CORE_RYF0304_JRA')
-       call datm_datamode_jra_advertise(exportState, fldsExport, flds_scalar_name, &
-            flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
+       call datm_datamode_jra_advertise(exportState, fldsExport, flds_scalar_name, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('CLMNCEP')
-       call datm_datamode_clmncep_advertise(exportState, fldsExport, flds_scalar_name, &
-            flds_co2, flds_wiso, flds_presaero, flds_presndep, flds_preso3, rc)
+       call datm_datamode_clmncep_advertise(exportState, fldsExport, flds_scalar_name, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('CPLHIST')
-       call datm_datamode_cplhist_advertise(exportState, fldsExport, flds_scalar_name, &
-            flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
+       call datm_datamode_cplhist_advertise(exportState, fldsExport, flds_scalar_name, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     case ('ERA5')
        call datm_datamode_era5_advertise(exportState, fldsExport, flds_scalar_name, rc)
@@ -603,7 +629,7 @@ contains
 
     ! local variables
     logical :: first_time = .true.
-    character(len=CL) :: rpfile        
+    character(len=CL) :: rpfile
     character(*), parameter :: subName = '(datm_comp_run) '
     !-------------------------------------------------------------------------------
 
@@ -616,11 +642,35 @@ contains
     !--------------------
 
     if (first_time) then
+       ! Initialize data pointers for co2 (non datamode specific)
+       if (flds_co2) then
+          call datm_pres_co2_init_pointers(exportState, sdat, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
+
+       ! Initialize data pointers for o3 (non datamode specific)
+       if (flds_preso3) then
+          call datm_pres_o3_init_pointers(exportState, sdat, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
+
+       ! Initialize data pointers for nitrogen deposition (non datamode specific and use of ungridded dimensions)
+       if (flds_presndep) then
+          call datm_pres_ndep_init_pointers(exportState, sdat, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
+
+       ! Initialize data pointers for prescribed aerosols (non datamode specific and use of ungridded dimensions)
+       if (flds_presaero) then
+          call datm_pres_aero_init_pointers(exportState, sdat, rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
+
        ! Initialize dfields
        call datm_init_dfields(rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-       ! Initialize datamode module ponters
+       ! Initialize datamode module pointers
        select case (trim(datamode))
        case('CORE2_NYF','CORE2_IAF')
           call datm_datamode_core2_init_pointers(exportState, sdat, datamode, factorfn_mesh, factorfn_data, rc)
@@ -650,7 +700,10 @@ contains
           call shr_get_rpointer_name(gcomp, 'atm', target_ymd, target_tod, rpfile, 'read', rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           select case (trim(datamode))
-          case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA','CORE_RYF6162_JRA','CORE_RYF8485_JRA','CORE_RYF9091_JRA','CORE_RYF0304_JRA','CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
+          case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA',&
+               'CORE_RYF6162_JRA','CORE_RYF8485_JRA' ,&
+               'CORE_RYF9091_JRA','CORE_RYF0304_JRA' ,&
+               'CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
              call dshr_restart_read(restfilm, rpfile, logunit, my_task, mpicom, sdat, rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           case default
@@ -718,9 +771,12 @@ contains
        call shr_get_rpointer_name(gcomp, 'atm', target_ymd, target_tod, rpfile, 'write', rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        select case (trim(datamode))
-       case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA','CORE_RYF6162_JRA','CORE_RYF8485_JRA','CORE_RYF9091_JRA','CORE_RYF0304_JRA','CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
-          call dshr_restart_write(rpfile, case_name, 'datm', inst_suffix, target_ymd, target_tod, logunit, &
-               my_task, sdat, rc)
+       case('CORE2_NYF','CORE2_IAF','CORE_IAF_JRA',&
+            'CORE_RYF6162_JRA','CORE_RYF8485_JRA' ,&
+            'CORE_RYF9091_JRA','CORE_RYF0304_JRA' ,&
+            'CLMNCEP','CPLHIST','ERA5','GEFS','SIMPLE')
+          call dshr_restart_write(rpfile, case_name, 'datm', inst_suffix, &
+               target_ymd, target_tod, logunit, my_task, sdat, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        case default
           call shr_log_error(subName//'datamode '//trim(datamode)//' not recognized', rc=rc)
@@ -783,53 +839,8 @@ contains
                  exportState, logunit, mainproc, rc=rc)
             if (ChkErr(rc,__LINE__,u_FILE_u)) return
          else if (rank == 2) then
-            ! The following maps stream input fields to export fields that have an ungridded dimension
-            ! TODO: in the future it might be better to change the format of the streams file to have two more entries
-            ! that could denote how the stream variables are mapped to export fields that have an ungridded dimension
-
-            select case (trim(lfieldnames(n)))
-            case('Faxa_bcph')
-               strm_flds3 = (/'Faxa_bcphidry', 'Faxa_bcphodry', 'Faxa_bcphiwet'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_ocph')
-               strm_flds3 = (/'Faxa_ocphidry', 'Faxa_ocphodry', 'Faxa_ocphiwet'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_dstwet')
-               strm_flds4 = (/'Faxa_dstwet1', 'Faxa_dstwet2', 'Faxa_dstwet3', 'Faxa_dstwet4'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds4, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_dstdry')
-               strm_flds4 = (/'Faxa_dstdry1', 'Faxa_dstdry2', 'Faxa_dstdry3', 'Faxa_dstdry4'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds4, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_rainc_wiso')
-               strm_flds3 = (/'Faxa_rainc_16O', 'Faxa_rainc_18O', 'Faxa_rainc_HDO'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_rainl_wiso')
-               strm_flds3 = (/'Faxa_rainl_16O', 'Faxa_rainl_18O', 'Faxa_rainl_HDO'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_snowc_wiso')
-               strm_flds3 = (/'Faxa_snowc_16O', 'Faxa_snowc_18O', 'Faxa_snowc_HDO'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_snowl_wiso')
-               strm_flds3 = (/'Faxa_snowl_16O', 'Faxa_snowl_18O', 'Faxa_snowl_HDO'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds3, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('Faxa_ndep')
-               strm_flds2 = (/'Faxa_ndep_nhx', 'Faxa_ndep_noy'/)
-               call dshr_dfield_add(dfields, sdat, trim(lfieldnames(n)), strm_flds2, exportState, logunit, mainproc, rc)
-               if (ChkErr(rc,__LINE__,u_FILE_u)) return
-            case('cpl_scalars')
-               continue
-            case default
-               call shr_log_error(subName//'field '//trim(lfieldnames(n))//' not recognized', rc=rc)
-               return
-            end select
+          call shr_log_error(subName//'rank == 2 pointers no longer supported in datm_init_dfields')
+          return
          end if
       end do
     end subroutine datm_init_dfields

--- a/datm/cime_config/buildnml
+++ b/datm/cime_config/buildnml
@@ -213,7 +213,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     if  clm_usrdat_name == 'NEON.PRISM':
         streamlist.append(clm_usrdat_name+"_PRECIP."+neonsite)
     if  clm_usrdat_name == 'NEON':
-        streamlist.append(clm_usrdat_name+".NEON_PRECIP."+neonsite)
+        streamlist.append(clm_usrdat_name+".NEON_PRECIP."+neonsite)   
     if clm_usrdat_name == 'PLUMBER2':
         streamlist.append(clm_usrdat_name+"."+plumber2site)
 
@@ -243,7 +243,7 @@ def _create_drv_flds_in(case, confdir):
 
     # for now we are hard-coding this file name and values because we only need it for ozone
     if datm_preso3 != "none":
-
+        
         # Generate drv_flds_in file
         outfile = os.path.join(confdir, "drv_flds_in")
         ozone_nl_name = "&ozone_coupling_nl"

--- a/datm/cime_config/buildnml
+++ b/datm/cime_config/buildnml
@@ -213,9 +213,10 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     if  clm_usrdat_name == 'NEON.PRISM':
         streamlist.append(clm_usrdat_name+"_PRECIP."+neonsite)
     if  clm_usrdat_name == 'NEON':
-        streamlist.append(clm_usrdat_name+".NEON_PRECIP."+neonsite)   
+        streamlist.append(clm_usrdat_name+".NEON_PRECIP."+neonsite)
     if clm_usrdat_name == 'PLUMBER2':
         streamlist.append(clm_usrdat_name+"."+plumber2site)
+    print (f"DEBUG: streamlist is {streamlist}")
 
     bias_correct = nmlgen.get_value("bias_correct")
     if bias_correct is not None:
@@ -243,7 +244,7 @@ def _create_drv_flds_in(case, confdir):
 
     # for now we are hard-coding this file name and values because we only need it for ozone
     if datm_preso3 != "none":
-        
+
         # Generate drv_flds_in file
         outfile = os.path.join(confdir, "drv_flds_in")
         ozone_nl_name = "&ozone_coupling_nl"

--- a/datm/cime_config/buildnml
+++ b/datm/cime_config/buildnml
@@ -216,7 +216,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         streamlist.append(clm_usrdat_name+".NEON_PRECIP."+neonsite)
     if clm_usrdat_name == 'PLUMBER2':
         streamlist.append(clm_usrdat_name+"."+plumber2site)
-    print (f"DEBUG: streamlist is {streamlist}")
 
     bias_correct = nmlgen.get_value("bias_correct")
     if bias_correct is not None:

--- a/datm/cime_config/buildnml
+++ b/datm/cime_config/buildnml
@@ -59,7 +59,7 @@ def _get_neon_data_availability(case, neonsite):
     neonatm = None
     dataversion = case.get_value("NEONVERSION")
     if dataversion == "latest":
-        dataversions = ["v3", "v2", "v1"]
+        dataversions = ["v4", "v3", "v2", "v1"]
     else:
         dataversions = [dataversion]
 

--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -102,18 +102,22 @@
 
   <entry id="DATM_PRESNDEP">
     <type>char</type>
-    <valid_values>none,clim_1850,clim_1850_cmip7,clim_2000,clim_2010,hist,hist_cmip7,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP5-3.4,SSP5-8.5,cplhist</valid_values>
+    <valid_values>none,
+      clim_1850_cmip7,clim_2000_cmip7,clim_2010_cmip7,clim_hist_cmip7,
+      clim_1850_cmip6,clim_2000_cmip6,hist,hist_cmip6,clim_hist_cmip6,
+      SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP5-3.4,SSP5-8.5,cplhist
+    </valid_values>
     <default_value>clim_2000</default_value>
     <values match="last">
-      <value compset="^1850[CE]?_"  >clim_1850</value>
-      <value compset="^2000_"       >clim_2000</value>
-      <value compset="^2010_"       >clim_2010</value>
+      <value compset="^1850[CE]?_"  >clim_1850_cmip7</value>
+      <value compset="^2000_"       >clim_2000_cmip7</value>
+      <value compset="^2010_"       >clim_2010_cmip7</value>
+      <value compset="^HIST[CE]?_"  >hist_cmip7</value>
+      <value compset="^20TR_"       >hist_cmip7</value>
       <value compset="^SSP126_"     >SSP1-2.6</value>
       <value compset="^SSP245_"     >SSP2-4.5</value>
       <value compset="^SSP370_"     >SSP3-7.0</value>
       <value compset="^SSP585_"     >SSP5-8.5</value>
-      <value compset="^HIST[CE]?_"  >hist</value>
-      <value compset="^20TR_"       >hist</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
       <value compset="_DATM.*_DICE.*_DOCN.*_DROF">none</value>
     </values>

--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -102,18 +102,18 @@
 
   <entry id="DATM_PRESNDEP">
     <type>char</type>
-    <valid_values>none,clim_1850,clim_2000,clim_2010,hist,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP5-3.4,SSP5-8.5,cplhist</valid_values>
+    <valid_values>none,clim_1850,clim_1850_cmpi7,clim_2000,clim_2010,hist,hist_cmip7,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP5-3.4,SSP5-8.5,cplhist</valid_values>
     <default_value>clim_2000</default_value>
     <values match="last">
-      <value compset="^1850[CE]?_"   >clim_1850</value>
-      <value compset="^2000_"   >clim_2000</value>
-      <value compset="^2010_"   >clim_2010</value>
-      <value compset="^SSP126_" >SSP1-2.6</value>
-      <value compset="^SSP245_" >SSP2-4.5</value>
-      <value compset="^SSP370_" >SSP3-7.0</value>
-      <value compset="^SSP585_" >SSP5-8.5</value>
-      <value compset="^HIST[CE]?_"   >hist</value>
-      <value compset="^20TR_"   >hist</value>
+      <value compset="^1850[CE]?_"  >clim_1850</value>
+      <value compset="^2000_"       >clim_2000</value>
+      <value compset="^2010_"       >clim_2010</value>
+      <value compset="^SSP126_"     >SSP1-2.6</value>
+      <value compset="^SSP245_"     >SSP2-4.5</value>
+      <value compset="^SSP370_"     >SSP3-7.0</value>
+      <value compset="^SSP585_"     >SSP5-8.5</value>
+      <value compset="^HIST[CE]?_"  >hist</value>
+      <value compset="^20TR_"       >hist</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
       <value compset="_DATM.*_DICE.*_DOCN.*_DROF">none</value>
     </values>

--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -102,7 +102,7 @@
 
   <entry id="DATM_PRESNDEP">
     <type>char</type>
-    <valid_values>none,clim_1850,clim_1850_cmpi7,clim_2000,clim_2010,hist,hist_cmip7,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP5-3.4,SSP5-8.5,cplhist</valid_values>
+    <valid_values>none,clim_1850,clim_1850_cmip7,clim_2000,clim_2010,hist,hist_cmip7,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP5-3.4,SSP5-8.5,cplhist</valid_values>
     <default_value>clim_2000</default_value>
     <values match="last">
       <value compset="^1850[CE]?_"  >clim_1850</value>

--- a/datm/cime_config/config_component.xml
+++ b/datm/cime_config/config_component.xml
@@ -103,8 +103,8 @@
   <entry id="DATM_PRESNDEP">
     <type>char</type>
     <valid_values>none,
-      clim_1850_cmip7,clim_2000_cmip7,clim_2010_cmip7,clim_hist_cmip7,
-      clim_1850_cmip6,clim_2000_cmip6,hist,hist_cmip6,clim_hist_cmip6,
+      clim_1850_cmip7,clim_2000_cmip7,clim_2010_cmip7,hist_cmip7,
+      clim_1850_cmip6,clim_2000_cmip6,clim_2010_cmip6,hist_cmip6,
       SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP5-3.4,SSP5-8.5,cplhist
     </valid_values>
     <default_value>clim_2000</default_value>

--- a/datm/cime_config/namelist_definition_datm.xml
+++ b/datm/cime_config/namelist_definition_datm.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <!-- Note that streamslist here does not handle the optional streams - -->

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -4872,7 +4872,7 @@
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of kg/m2/sec - so need no unit conversion -->
-      <var>drynhx  Faxandep_nhx_dry</var>
+      <var>drynhx  Faxa_ndep_nhx_dry</var>
       <var>wetnhx  Faxa_ndep_nhx_wet</var>
       <var>drynoy  Faxa_ndep_noy_dry</var>
       <var>wetnoy  Faxa_ndep_noy_wet</var>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -190,9 +190,11 @@
   optional stream nitrogen deposition
   - DATM_NDEP is set by the 4 character time prefix in config_component.xml
   ========================
+  presndep.clim_1850_cmip7
   presndep.clim_1850
   presndep.clim_2000
   presndep.clim_2010
+  presndep.hist_cmip7
   presndep.hist
   presndep.SSP1-2.6
   presndep.SSP2-4.5
@@ -4861,6 +4863,76 @@
   <!--  presndep forcing streams -->
   <!-- ===================-->
 
+  <stream_entry name="presndep.clim_1850_cmip7">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_ESMFmesh_cdf5_c20251211.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_CMIP_FZJ-CMIP-nitrogen-1-2_gn_185001-202212.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <!-- the following stream fields are in units of kg/m2/sec - so need no unit conversion -->
+      <var>drynhx  Faxandep_nhx_dry</var>
+      <var>wetnhx  Faxa_ndep_nhx_wet</var>
+      <var>drynoy  Faxa_ndep_noy_dry</var>
+      <var>wetnoy  Faxa_ndep_noy_wet</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>1</stream_year_align>
+    <stream_year_first>1850</stream_year_first>
+    <stream_year_last>1850</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
+  <stream_entry name="presndep.hist_cmip7">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_ESMFmesh_cdf5_c20251211.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_CMIP_FZJ-CMIP-nitrogen-1-2_gn_185001-202212.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <!-- the following stream fields are in units of kg/m2/sec - so need no unit conversion -->
+      <var>drynhx  Faxa_ndep_nhx_dry</var>
+      <var>wetnhx  Faxa_ndep_nhx_wet</var>
+      <var>drynoy  Faxa_ndep_noy_dry</var>
+      <var>wetnoy  Faxa_ndep_noy_wet</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>1</stream_year_align>
+    <stream_year_first>1850</stream_year_first>
+    <stream_year_last>2022</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
   <stream_entry name="presndep.clim_1850">
     <stream_meshfile>
       <meshfile>$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</meshfile>
@@ -4869,6 +4941,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>
@@ -4901,6 +4974,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>
@@ -4965,6 +5039,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>
@@ -4997,6 +5072,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP1-2.6-WACCM_1849-2101_monthly_c191007.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>
@@ -5029,6 +5105,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP2-4.5-WACCM_1849-2101_monthly_c191007.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>
@@ -5061,6 +5138,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_SSP370_b.e21.BWSSP370cmip6.f09_g17.CMIP6-SSP3-7.0-WACCM.002_1849-2101_monthly_0.9x1.25_c211216.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>
@@ -5094,6 +5172,7 @@
       <file>$DIN_LOC_ROOT/lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP5-8.5-WACCM_1849-2101_monthly_c191007.nc</file>
     </stream_datafiles>
     <stream_datavars>
+      <!-- the following stream fields are in units of g/m2/sec - need conversion to kg/m2/sec-->
       <var>NDEP_NHx_month  Faxa_ndep_nhx</var>
       <var>NDEP_NOy_month  Faxa_ndep_noy</var>
     </stream_datavars>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -189,11 +189,13 @@
   - DATM_NDEP is set by the 4 character time prefix in config_component.xml
   ========================
   presndep.clim_1850_cmip7
-  presndep.clim_1850
-  presndep.clim_2000
-  presndep.clim_2010
+  presndep.clim_2000_cmip7
+  presndep.clim_2010_cmip7
   presndep.hist_cmip7
-  presndep.hist
+  presndep.clim_1850_cmip6
+  presndep.clim_2000_cmip6
+  presndep.clim_2010_cmip6
+  presndep.hist_cmip6
   presndep.SSP1-2.6
   presndep.SSP2-4.5
   presndep.SSP3-7.0
@@ -4896,6 +4898,76 @@
     <stream_readmode>single</stream_readmode>
   </stream_entry>
 
+  <stream_entry name="presndep.clim_2000_cmip7">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_ESMFmesh_cdf5_c20251211.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_CMIP_FZJ-CMIP-nitrogen-1-2_gn_185001-202212_c20251222.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <!-- the following stream fields are in units of kg/m2/sec - so need no unit conversion -->
+      <var>drynhx  Faxa_ndep_nhx_dry</var>
+      <var>wetnhx  Faxa_ndep_nhx_wet</var>
+      <var>drynoy  Faxa_ndep_noy_dry</var>
+      <var>wetnoy  Faxa_ndep_noy_wet</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>1</stream_year_align>
+    <stream_year_first>2000</stream_year_first>
+    <stream_year_last>2000</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
+  <stream_entry name="presndep.clim_2010_cmip7">
+    <stream_meshfile>
+      <meshfile>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_ESMFmesh_cdf5_c20251211.nc</meshfile>
+    </stream_meshfile>
+    <stream_datafiles>
+      <file>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_CMIP_FZJ-CMIP-nitrogen-1-2_gn_185001-202212_c20251222.nc</file>
+    </stream_datafiles>
+    <stream_datavars>
+      <!-- the following stream fields are in units of kg/m2/sec - so need no unit conversion -->
+      <var>drynhx  Faxa_ndep_nhx_dry</var>
+      <var>wetnhx  Faxa_ndep_nhx_wet</var>
+      <var>drynoy  Faxa_ndep_noy_dry</var>
+      <var>wetnoy  Faxa_ndep_noy_wet</var>
+    </stream_datavars>
+    <stream_lev_dimname>null</stream_lev_dimname>
+    <stream_mapalgo>
+      <mapalgo>bilinear</mapalgo>
+    </stream_mapalgo>
+    <stream_vectors>null</stream_vectors>
+    <stream_year_align>1</stream_year_align>
+    <stream_year_first>2010</stream_year_first>
+    <stream_year_last>2010</stream_year_last>
+    <stream_offset>0</stream_offset>
+    <stream_tintalgo>
+      <tintalgo>linear</tintalgo>
+    </stream_tintalgo>
+    <stream_taxmode>
+      <taxmode>cycle</taxmode>
+    </stream_taxmode>
+    <stream_dtlimit>
+      <dtlimit>1.5</dtlimit>
+    </stream_dtlimit>
+    <stream_readmode>single</stream_readmode>
+  </stream_entry>
+
   <stream_entry name="presndep.hist_cmip7">
     <stream_meshfile>
       <meshfile>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_ESMFmesh_cdf5_c20251211.nc</meshfile>
@@ -4931,7 +5003,7 @@
     <stream_readmode>single</stream_readmode>
   </stream_entry>
 
-  <stream_entry name="presndep.clim_1850">
+  <stream_entry name="presndep.clim_1850_cmip6">
     <stream_meshfile>
       <meshfile>$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</meshfile>
     </stream_meshfile>
@@ -4964,7 +5036,7 @@
     <stream_readmode>single</stream_readmode>
   </stream_entry>
 
-  <stream_entry name="presndep.clim_2000">
+  <stream_entry name="presndep.clim_2000_cmip6">
     <stream_meshfile>
       <meshfile>$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</meshfile>
     </stream_meshfile>
@@ -4997,7 +5069,7 @@
     <stream_readmode>single</stream_readmode>
   </stream_entry>
 
-  <stream_entry name="presndep.clim_2010">
+  <stream_entry name="presndep.clim_2010_cmip6">
     <stream_meshfile>
       <meshfile>$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</meshfile>
     </stream_meshfile>
@@ -5029,7 +5101,7 @@
     <stream_readmode>single</stream_readmode>
   </stream_entry>
 
-  <stream_entry name="presndep.hist">
+  <stream_entry name="presndep.hist_cmip6">
     <stream_meshfile>
       <meshfile>$DIN_LOC_ROOT/share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</meshfile>
     </stream_meshfile>

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <stream_data version="2.0" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <!-- TODO: when should the mapalgo be nn? -->

--- a/datm/cime_config/stream_definition_datm.xml
+++ b/datm/cime_config/stream_definition_datm.xml
@@ -4868,7 +4868,7 @@
       <meshfile>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_ESMFmesh_cdf5_c20251211.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_CMIP_FZJ-CMIP-nitrogen-1-2_gn_185001-202212.nc</file>
+      <file>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_CMIP_FZJ-CMIP-nitrogen-1-2_gn_185001-185012-clim_c20251222.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of kg/m2/sec - so need no unit conversion -->
@@ -4903,7 +4903,7 @@
       <meshfile>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_ESMFmesh_cdf5_c20251211.nc</meshfile>
     </stream_meshfile>
     <stream_datafiles>
-      <file>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_CMIP_FZJ-CMIP-nitrogen-1-2_gn_185001-202212.nc</file>
+      <file>$DIN_LOC_ROOT/atm/ndep/cmip7/ndep_input4MIPs_surfaceFluxes_CMIP_FZJ-CMIP-nitrogen-1-2_gn_185001-202212_c20251222.nc</file>
     </stream_datafiles>
     <stream_datavars>
       <!-- the following stream fields are in units of kg/m2/sec - so need no unit conversion -->

--- a/datm/datm_datamode_clmncep_mod.F90
+++ b/datm/datm_datamode_clmncep_mod.F90
@@ -184,20 +184,6 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_strdata_get_stream_pointer( sdat, 'Faxa_precn'     , strm_precn , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_rh_16O'    , strm_rh_16O, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_rh_18O'    , strm_rh_18O   , rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_rh_HDO'    , strm_rh_HDO   , rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_precn_16O' , strm_precn_16O, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_precn_18O' , strm_precn_18O, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_precn_HDO' , strm_precn_HDO, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_precn_HDO' , strm_precn_HDO, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! initialize pointers for module level stream arrays for bias correction
     call shr_strdata_get_stream_pointer( sdat, 'Faxa_precsf'   , strm_precsf   , rc)

--- a/datm/datm_datamode_clmncep_mod.F90
+++ b/datm/datm_datamode_clmncep_mod.F90
@@ -14,11 +14,12 @@ module datm_datamode_clmncep_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_clmncep_advertise
   public  :: datm_datamode_clmncep_init_pointers
   public  :: datm_datamode_clmncep_advance
+
   private :: datm_esat  ! determine saturation vapor pressure
 
   ! export state data
@@ -88,8 +89,8 @@ module datm_datamode_clmncep_mod
   real(r8) , parameter :: stebol   = SHR_CONST_STEBOL   ! Stefan-Boltzmann constant ~ W/m^2/K^4
   real(r8) , parameter :: rdair    = SHR_CONST_RDAIR    ! dry air gas constant   ~ J/K/kg
 
-  character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'null'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
@@ -249,7 +250,7 @@ contains
 
     ! error check
     if (.not. associated(strm_wind) .or. .not. associated(strm_tbot)) then
-       call shr_log_error(trim(subname)//' ERROR: wind and tbot must be in streams for CLMNCEP', rc=rc)
+       call shr_log_error(subname//' ERROR: wind and tbot must be in streams for CLMNCEP', rc=rc)
        return
     endif
 
@@ -309,7 +310,7 @@ contains
        call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        tbotmax = rtmp(2)
-       if (mainproc) write(logunit,*) trim(subname),' tbotmax = ',tbotmax
+       if (mainproc) write(logunit,*) subname,' tbotmax = ',tbotmax
        if(tbotmax <= 0) then
           call shr_log_error(subname//'ERROR: bad value in tbotmax', rc=rc)
           return
@@ -324,7 +325,7 @@ contains
        else
           anidrmax = SHR_CONST_SPVAL
        end if
-       if (mainproc) write(logunit,*) trim(subname),' anidrmax = ',anidrmax
+       if (mainproc) write(logunit,*) subname,' anidrmax = ',anidrmax
 
        ! determine tdewmax (see below for use)
        if (associated(strm_tdew)) then
@@ -332,7 +333,7 @@ contains
           call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           tdewmax = rtmp(2)
-          if (mainproc) write(logunit,*) trim(subname),' tdewmax = ',tdewmax
+          if (mainproc) write(logunit,*) subname,' tdewmax = ',tdewmax
        endif
 
        ! reset first_time

--- a/datm/datm_datamode_core2_mod.F90
+++ b/datm/datm_datamode_core2_mod.F90
@@ -26,7 +26,7 @@ module datm_datamode_core2_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_core2_advertise
   public  :: datm_datamode_core2_init_pointers
@@ -81,8 +81,8 @@ module datm_datamode_core2_mod
   data   dTarc      / 0.49_R8, 0.06_R8,-0.73_R8,  -0.89_R8,-0.77_R8,-1.02_R8, &
                      -1.99_R8,-0.91_R8, 1.72_R8,   2.30_R8, 1.81_R8, 1.06_R8/
 
-  character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'null'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
@@ -227,13 +227,13 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (.not. associated(strm_prec) .or. .not. associated(strm_swdn)) then
-       call shr_log_error(trim(subname)//'ERROR: prec and swdn must be in streams for CORE2', rc=rc)
+       call shr_log_error(subname//'ERROR: prec and swdn must be in streams for CORE2', rc=rc)
        return
     endif
 
     if (trim(datamode) == 'CORE2_IAF' ) then
        if (.not. associated(strm_tarcf)) then
-          call shr_log_error(trim(subname)//'tarcf must be in an input stream for CORE2_IAF', rc=rc)
+          call shr_log_error(subname//'tarcf must be in an input stream for CORE2_IAF', rc=rc)
           return
        endif
     endif
@@ -372,8 +372,8 @@ contains
 
     ! input/output variables
     type(shr_strdata_type) , intent(in)  :: sdat
-    character(*)           , intent(in)  :: fileName_mesh ! file name string
-    character(*)           , intent(in)  :: fileName_data ! file name string
+    character(len=*)       , intent(in)  :: fileName_mesh ! file name string
+    character(len=*)       , intent(in)  :: fileName_data ! file name string
     real(R8)               , pointer     :: windF(:)      ! wind adjustment factor
     real(R8)               , pointer     :: winddF(:)     ! wind adjustment factor
     real(r8)               , pointer     :: qsatF(:)      ! rel humidty adjustment factor
@@ -398,7 +398,7 @@ contains
     integer                :: nxg, nyg
     real(r8), pointer      :: data(:)
     integer                :: srcTermProcessing_Value = 0
-    character(*) ,parameter :: subName =  '(datm_get_adjustment_factors) '
+    character(len=*) ,parameter :: subName =  '(datm_get_adjustment_factors) '
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS

--- a/datm/datm_datamode_core2_mod.F90
+++ b/datm/datm_datamode_core2_mod.F90
@@ -55,7 +55,6 @@ module datm_datamode_core2_mod
   real(r8), pointer :: Faxa_swvdr(:) => null()
   real(r8), pointer :: Faxa_swvdf(:) => null()
   real(r8), pointer :: Faxa_swnet(:) => null()
-  real(r8), pointer :: Faxa_ndep(:,:) => null()
 
   ! stream data
   real(r8), pointer :: strm_prec(:)      => null()
@@ -90,17 +89,12 @@ module datm_datamode_core2_mod
 contains
 !===============================================================================
 
-  subroutine datm_datamode_core2_advertise(exportState, fldsexport, flds_scalar_name, &
-       flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
+  subroutine datm_datamode_core2_advertise(exportState, fldsexport, flds_scalar_name, rc)
 
     ! input/output variables
     type(esmf_State)   , intent(inout) :: exportState
     type(fldlist_type) , pointer       :: fldsexport
     character(len=*)   , intent(in)    :: flds_scalar_name
-    logical            , intent(in)    :: flds_co2
-    logical            , intent(in)    :: flds_wiso
-    logical            , intent(in)    :: flds_presaero
-    logical            , intent(in)    :: flds_presndep
     integer            , intent(out)   :: rc
 
     ! local variables
@@ -132,27 +126,6 @@ contains
     call dshr_fldList_add(fldsExport, 'Faxa_swnet' )
     call dshr_fldList_add(fldsExport, 'Faxa_lwdn'  )
     call dshr_fldList_add(fldsExport, 'Faxa_swdn'  )
-
-    if (flds_co2) then
-       call dshr_fldList_add(fldsExport, 'Sa_co2prog')
-       call dshr_fldList_add(fldsExport, 'Sa_co2diag')
-    end if
-    if (flds_presaero) then
-       call dshr_fldList_add(fldsExport, 'Faxa_bcph'   , ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_ocph'   , ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_dstwet' , ungridded_lbound=1, ungridded_ubound=4)
-       call dshr_fldList_add(fldsExport, 'Faxa_dstdry' , ungridded_lbound=1, ungridded_ubound=4)
-    end if
-    if (flds_presndep) then
-       call dshr_fldList_add(fldsExport, 'Faxa_ndep', ungridded_lbound=1, ungridded_ubound=2)
-    end if
-    if (flds_wiso) then
-       call dshr_fldList_add(fldsExport, 'Faxa_rainc_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_rainl_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_snowc_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_snowl_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_shum_wiso' , ungridded_lbound=1, ungridded_ubound=3)
-    end if
 
     fldlist => fldsExport ! the head of the linked list
     do while (associated(fldlist))
@@ -253,13 +226,6 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call dshr_state_getfldptr(exportState, 'Faxa_lwdn'  , fldptr1=Faxa_lwdn  , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    call ESMF_StateGet(exportstate, 'Faxa_ndep', itemFlag, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (itemflag /= ESMF_STATEITEM_NOTFOUND) then
-       call dshr_state_getfldptr(exportState, 'Faxa_ndep', fldptr2=Faxa_ndep, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
 
     if (.not. associated(strm_prec) .or. .not. associated(strm_swdn)) then
        call shr_log_error(trim(subname)//'ERROR: prec and swdn must be in streams for CORE2', rc=rc)
@@ -399,11 +365,6 @@ contains
        endif
 
     enddo   ! lsize
-
-    if (associated(Faxa_ndep)) then
-       ! convert ndep flux to units of kgN/m2/s (input is in gN/m2/s)
-       Faxa_ndep(:,:) = Faxa_ndep(:,:) / 1000._r8
-    end if
 
   end subroutine datm_datamode_core2_advance
 

--- a/datm/datm_datamode_core2_mod.F90
+++ b/datm/datm_datamode_core2_mod.F90
@@ -154,7 +154,6 @@ contains
     integer           :: spatialDim         ! number of dimension in mesh
     integer           :: numOwnedElements   ! size of mesh
     real(r8), pointer :: ownedElemCoords(:) ! mesh lat and lons
-    type(ESMF_StateItem_Flag) :: itemFlag
     character(len=*), parameter :: subname='(datm_init_pointers): '
     !-------------------------------------------------------------------------------
 

--- a/datm/datm_datamode_cplhist_mod.F90
+++ b/datm/datm_datamode_cplhist_mod.F90
@@ -11,7 +11,7 @@ module datm_datamode_cplhist_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_cplhist_advertise
   public  :: datm_datamode_cplhist_init_pointers
@@ -37,8 +37,8 @@ module datm_datamode_cplhist_mod
   real(r8), pointer :: Faxa_swvdr(:)        => null()
   real(r8), pointer :: Faxa_swvdf(:)        => null()
 
-  character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'null'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================

--- a/datm/datm_datamode_cplhist_mod.F90
+++ b/datm/datm_datamode_cplhist_mod.F90
@@ -24,8 +24,6 @@ module datm_datamode_cplhist_mod
   real(r8), pointer :: Sa_tbot(:)           => null()
   real(r8), pointer :: Sa_ptem(:)           => null()
   real(r8), pointer :: Sa_shum(:)           => null()
-  ! TODO: water isotope support
-  !  real(r8), pointer :: Sa_shum_wiso(:,:)    => null() ! water isotopes
   real(r8), pointer :: Sa_dens(:)           => null()
   real(r8), pointer :: Sa_pbot(:)           => null()
   real(r8), pointer :: Sa_pslv(:)           => null()
@@ -39,7 +37,6 @@ module datm_datamode_cplhist_mod
   real(r8), pointer :: Faxa_swvdr(:)        => null()
   real(r8), pointer :: Faxa_swvdf(:)        => null()
   real(r8), pointer :: Faxa_swnet(:)        => null()
-  real(r8), pointer :: Faxa_ndep(:,:)       => null()
 
   character(*), parameter :: nullstr = 'null'
   character(*), parameter :: u_FILE_u = &
@@ -49,16 +46,11 @@ module datm_datamode_cplhist_mod
 contains
 !===============================================================================
 
-  subroutine datm_datamode_cplhist_advertise(exportState, fldsexport, flds_scalar_name, &
-       flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
+  subroutine datm_datamode_cplhist_advertise(exportState, fldsexport, flds_scalar_name, rc)
 
     ! input/output variables
     type(esmf_State)   , intent(inout) :: exportState
     type(fldlist_type) , pointer       :: fldsexport
-    logical            , intent(in)    :: flds_co2
-    logical            , intent(in)    :: flds_wiso
-    logical            , intent(in)    :: flds_presaero
-    logical            , intent(in)    :: flds_presndep
     character(len=*)   , intent(in)    :: flds_scalar_name
     integer            , intent(out)   :: rc
 
@@ -90,26 +82,6 @@ contains
     call dshr_fldList_add(fldsExport, 'Faxa_swnet' )
     call dshr_fldList_add(fldsExport, 'Faxa_lwdn'  )
     call dshr_fldList_add(fldsExport, 'Faxa_swdn'  )
-    if (flds_co2) then
-       call dshr_fldList_add(fldsExport, 'Sa_co2prog')
-       call dshr_fldList_add(fldsExport, 'Sa_co2diag')
-    end if
-    if (flds_presaero) then
-       call dshr_fldList_add(fldsExport, 'Faxa_bcph'   , ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_ocph'   , ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_dstwet' , ungridded_lbound=1, ungridded_ubound=4)
-       call dshr_fldList_add(fldsExport, 'Faxa_dstdry' , ungridded_lbound=1, ungridded_ubound=4)
-    end if
-    if (flds_presndep) then
-       call dshr_fldList_add(fldsExport, 'Faxa_ndep', ungridded_lbound=1, ungridded_ubound=2)
-    end if
-    if (flds_wiso) then
-       call dshr_fldList_add(fldsExport, 'Faxa_rainc_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_rainl_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_snowc_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_snowl_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_shum_wiso' , ungridded_lbound=1, ungridded_ubound=3)
-    end if
 
     fldlist => fldsExport ! the head of the linked list
     do while (associated(fldlist))
@@ -177,13 +149,6 @@ contains
     call dshr_state_getfldptr(exportState, 'Faxa_lwdn'  , fldptr1=Faxa_lwdn  , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_StateGet(exportState, 'Faxa_ndep', itemFlag, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (itemflag /= ESMF_STATEITEM_NOTFOUND) then
-       call dshr_state_getfldptr(exportState, 'Faxa_ndep', fldptr2=Faxa_ndep, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
-
  end subroutine datm_datamode_cplhist_init_pointers
 
   !===============================================================================
@@ -200,11 +165,6 @@ contains
     !-------------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
-
-    if (associated(Faxa_ndep)) then
-       ! convert ndep flux to units of kgN/m2/s (assumes that input is in gN/m2/s)
-       Faxa_ndep(:,:) = Faxa_ndep(:,:) / 1000._r8
-    end if
 
   end subroutine datm_datamode_cplhist_advance
 

--- a/datm/datm_datamode_cplhist_mod.F90
+++ b/datm/datm_datamode_cplhist_mod.F90
@@ -36,7 +36,6 @@ module datm_datamode_cplhist_mod
   real(r8), pointer :: Faxa_swndf(:)        => null()
   real(r8), pointer :: Faxa_swvdr(:)        => null()
   real(r8), pointer :: Faxa_swvdf(:)        => null()
-  real(r8), pointer :: Faxa_ndep(:,:)       => null()
 
   character(*), parameter :: nullstr = 'null'
   character(*), parameter :: u_FILE_u = &

--- a/datm/datm_datamode_cplhist_mod.F90
+++ b/datm/datm_datamode_cplhist_mod.F90
@@ -103,7 +103,6 @@ contains
     integer                , intent(out)   :: rc
 
     ! local variables
-    type(ESMF_StateItem_Flag) :: itemFlag
     character(len=*), parameter :: subname='(datm_init_pointers): '
     !-------------------------------------------------------------------------------
 

--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -44,8 +44,6 @@ module datm_datamode_era5_mod
   real(r8), pointer :: Faxa_lat(:)          => null()
   real(r8), pointer :: Faxa_taux(:)         => null()
   real(r8), pointer :: Faxa_tauy(:)         => null()
-!
-!  real(r8), pointer :: Faxa_ndep(:,:)       => null()
 
   ! stream data
   real(r8), pointer :: strm_tdew(:)         => null()
@@ -189,7 +187,7 @@ contains
 
   end subroutine datm_datamode_era5_init_pointers
 
-  !===============================================================================  
+  !===============================================================================
   subroutine datm_datamode_era5_advance(exportstate, mainproc, logunit, mpicom, target_ymd, target_tod, model_calendar, rc)
     use ESMF, only: ESMF_VMGetCurrent, ESMF_VMAllReduce, ESMF_REDUCE_MAX, ESMF_VM
 
@@ -312,7 +310,7 @@ contains
 
   end subroutine datm_datamode_era5_advance
 
-  !===============================================================================  
+  !===============================================================================
   real(r8) function datm_eSat(tK,tKbot)
 
     !----------------------------------------------------------------------------

--- a/datm/datm_datamode_era5_mod.F90
+++ b/datm/datm_datamode_era5_mod.F90
@@ -11,11 +11,12 @@ module datm_datamode_era5_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_era5_advertise
   public  :: datm_datamode_era5_init_pointers
   public  :: datm_datamode_era5_advance
+
   private :: datm_eSat  ! determine saturation vapor pressure
 
   ! export state data
@@ -55,8 +56,8 @@ module datm_datamode_era5_mod
   real(r8) , parameter :: rdair    = SHR_CONST_RDAIR ! dry air gas constant ~ J/K/kg
   real(r8) , parameter :: rhofw    = SHR_CONST_RHOFW ! density of fresh water ~ kg/m^3
 
-  character(*), parameter :: nullstr = 'undefined'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'undefined'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
@@ -223,7 +224,7 @@ contains
 
          call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
          t2max = rtmp(2)
-         if (mainproc) write(logunit,*) trim(subname),' t2max = ',t2max
+         if (mainproc) write(logunit,*) subname,' t2max = ',t2max
        end if
 
        ! determine tdewmax (see below for use)
@@ -231,7 +232,7 @@ contains
        call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
        td2max = rtmp(2)
 
-       if (mainproc) write(logunit,*) trim(subname),' td2max = ',td2max
+       if (mainproc) write(logunit,*) subname,' td2max = ',td2max
 
        ! reset first_time
        first_time = .false.

--- a/datm/datm_datamode_gefs_mod.F90
+++ b/datm/datm_datamode_gefs_mod.F90
@@ -11,7 +11,7 @@ module datm_datamode_gefs_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_gefs_advertise
   public  :: datm_datamode_gefs_init_pointers
@@ -47,8 +47,8 @@ module datm_datamode_gefs_mod
   real(r8) , parameter :: rdair    = SHR_CONST_RDAIR ! dry air gas constant ~ J/K/kg
   real(r8) , parameter :: rhofw    = SHR_CONST_RHOFW ! density of fresh water ~ kg/m^3
 
-  character(*), parameter :: nullstr = 'undefined'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'undefined'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
@@ -193,14 +193,14 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        tbotmax = rtmp(2)
 
-       if (mainproc) write(logunit,*) trim(subname),' tbotmax = ',tbotmax
+       if (mainproc) write(logunit,*) subname,' tbotmax = ',tbotmax
 
        ! determine maskmax (see below for use)
        rtmp(1) = maxval(strm_mask(:))
        call ESMF_VMAllReduce(vm, rtmp, rtmp(2:), 1, ESMF_REDUCE_MAX, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        maskmax = rtmp(2)
-       if (mainproc) write(logunit,*) trim(subname),' maskmax = ',maskmax
+       if (mainproc) write(logunit,*) subname,' maskmax = ',maskmax
 
        ! reset first_time
        first_time = .false.

--- a/datm/datm_datamode_jra_mod.F90
+++ b/datm/datm_datamode_jra_mod.F90
@@ -41,7 +41,6 @@ module datm_datamode_jra_mod
   real(r8), pointer :: Faxa_swvdr(:) => null()
   real(r8), pointer :: Faxa_swvdf(:) => null()
   real(r8), pointer :: Faxa_swnet(:) => null()
-  real(r8), pointer :: Faxa_ndep(:,:) => null()
 
   ! stream data
   real(r8), pointer :: strm_prec(:)  => null()
@@ -65,17 +64,12 @@ module datm_datamode_jra_mod
 contains
 !===============================================================================
 
-  subroutine datm_datamode_jra_advertise(exportState, fldsexport, flds_scalar_name, &
-       flds_co2, flds_wiso, flds_presaero, flds_presndep, rc)
+  subroutine datm_datamode_jra_advertise(exportState, fldsexport, flds_scalar_name, rc)
 
     ! input/output variables
     type(esmf_State)   , intent(inout) :: exportState
     type(fldlist_type) , pointer       :: fldsexport
     character(len=*)   , intent(in)    :: flds_scalar_name
-    logical            , intent(in)    :: flds_co2
-    logical            , intent(in)    :: flds_wiso
-    logical            , intent(in)    :: flds_presaero
-    logical            , intent(in)    :: flds_presndep
     integer            , intent(out)   :: rc
 
     ! local variables
@@ -107,27 +101,6 @@ contains
     call dshr_fldList_add(fldsExport, 'Faxa_swnet' )
     call dshr_fldList_add(fldsExport, 'Faxa_lwdn'  )
     call dshr_fldList_add(fldsExport, 'Faxa_swdn'  )
-
-    if (flds_co2) then
-       call dshr_fldList_add(fldsExport, 'Sa_co2prog')
-       call dshr_fldList_add(fldsExport, 'Sa_co2diag')
-    end if
-    if (flds_presaero) then
-       call dshr_fldList_add(fldsExport, 'Faxa_bcph'   , ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_ocph'   , ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_dstwet' , ungridded_lbound=1, ungridded_ubound=4)
-       call dshr_fldList_add(fldsExport, 'Faxa_dstdry' , ungridded_lbound=1, ungridded_ubound=4)
-    end if
-    if (flds_presndep) then
-       call dshr_fldList_add(fldsExport, 'Faxa_ndep', ungridded_lbound=1, ungridded_ubound=2)
-    end if
-    if (flds_wiso) then
-       call dshr_fldList_add(fldsExport, 'Faxa_rainc_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_rainl_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_snowc_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_snowl_wiso', ungridded_lbound=1, ungridded_ubound=3)
-       call dshr_fldList_add(fldsExport, 'Faxa_shum_wiso' , ungridded_lbound=1, ungridded_ubound=3)
-    end if
 
     fldlist => fldsExport ! the head of the linked list
     do while (associated(fldlist))
@@ -217,13 +190,6 @@ contains
     call dshr_state_getfldptr(exportState, 'Faxa_swnet' , fldptr1=Faxa_swnet , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_StateGet(exportState, 'Faxa_ndep', itemFlag, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (itemflag /= ESMF_STATEITEM_NOTFOUND) then
-       call dshr_state_getfldptr(exportState, 'Faxa_ndep', fldptr2=Faxa_ndep, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
-
     ! erro check
     if (.not. associated(strm_prec) .or. .not. associated(strm_swdn)) then
        call shr_log_error(trim(subname)//'ERROR: prec and swdn must be in streams for CORE_IAF_JRA', rc=rc)
@@ -292,11 +258,6 @@ contains
        avg_alb = ( 0.069 - 0.011*cos(2.0_R8*yc(n)*degtorad ) )
        Faxa_swnet(n) = strm_swdn(n)*(1.0_R8 - avg_alb)
     enddo   ! lsize
-
-    if (associated(Faxa_ndep)) then
-       ! convert ndep flux to units of kgN/m2/s (input is in gN/m2/s)
-       Faxa_ndep(:,:) = Faxa_ndep(:,:) / 1000._r8
-    end if
 
   end subroutine datm_datamode_jra_advance
 

--- a/datm/datm_datamode_jra_mod.F90
+++ b/datm/datm_datamode_jra_mod.F90
@@ -14,7 +14,7 @@ module datm_datamode_jra_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_jra_advertise
   public  :: datm_datamode_jra_init_pointers
@@ -56,8 +56,8 @@ module datm_datamode_jra_mod
   real(R8) , parameter :: phs_c0   =   0.298_R8
   real(R8) , parameter :: dLWarc   =  -5.000_R8
 
-  character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'null'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
@@ -191,7 +191,7 @@ contains
 
     ! erro check
     if (.not. associated(strm_prec) .or. .not. associated(strm_swdn)) then
-       call shr_log_error(trim(subname)//'ERROR: prec and swdn must be in streams for CORE_IAF_JRA', rc=rc)
+       call shr_log_error(subname//'ERROR: prec and swdn must be in streams for CORE_IAF_JRA', rc=rc)
        return
     endif
 

--- a/datm/datm_datamode_jra_mod.F90
+++ b/datm/datm_datamode_jra_mod.F90
@@ -126,7 +126,6 @@ contains
     integer           :: spatialDim         ! number of dimension in mesh
     integer           :: numOwnedElements   ! size of mesh
     real(r8), pointer :: ownedElemCoords(:) ! mesh lat and lons
-    type(ESMF_StateItem_Flag) :: itemFlag
     character(len=*), parameter :: subname='(datm_init_pointers): '
     !-------------------------------------------------------------------------------
 

--- a/datm/datm_datamode_simple_mod.F90
+++ b/datm/datm_datamode_simple_mod.F90
@@ -190,7 +190,6 @@ contains
     integer           :: spatialDim         ! number of dimension in mesh
     integer           :: numOwnedElements   ! size of mesh
     real(r8), pointer :: ownedElemCoords(:) ! mesh lat and lons
-    type(ESMF_StateItem_Flag) :: itemFlag
     character(len=*), parameter :: subname='(datm_init_pointers): '
     !-------------------------------------------------------------------------------
 

--- a/datm/datm_datamode_simple_mod.F90
+++ b/datm/datm_datamode_simple_mod.F90
@@ -27,7 +27,7 @@ module datm_datamode_simple_mod
   use shr_log_mod      , only : shr_log_error
 
   implicit none
-  private ! except
+  private
 
   public  :: datm_datamode_simple_advertise
   public  :: datm_datamode_simple_init_pointers
@@ -74,8 +74,8 @@ module datm_datamode_simple_mod
   real(R8) , parameter :: phs_c0   =   0.298_R8
   real(R8) , parameter :: dLWarc   =  -5.000_R8
 
-  character(*), parameter :: nullstr = 'null'
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: nullstr = 'null'
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================

--- a/datm/datm_datamode_simple_mod.F90
+++ b/datm/datm_datamode_simple_mod.F90
@@ -25,7 +25,7 @@ module datm_datamode_simple_mod
   use dshr_strdata_mod , only : shr_strdata_type
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
   use shr_log_mod      , only : shr_log_error
-  
+
   implicit none
   private ! except
 
@@ -53,7 +53,6 @@ module datm_datamode_simple_mod
   real(r8), pointer :: Faxa_swvdr(:) => null()
   real(r8), pointer :: Faxa_swvdf(:) => null()
   real(r8), pointer :: Faxa_swnet(:) => null()
-  real(r8), pointer :: Faxa_ndep(:,:) => null()
 
   ! othe module arrays
   real(R8), pointer :: yc(:)                 ! array of model latitudes
@@ -251,13 +250,6 @@ contains
     call dshr_state_getfldptr(exportState, 'Faxa_lwdn'  , fldptr1=Faxa_lwdn  , rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call ESMF_StateGet(exportstate, 'Faxa_ndep', itemFlag, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (itemflag /= ESMF_STATEITEM_NOTFOUND) then
-       call dshr_state_getfldptr(exportState, 'Faxa_ndep', fldptr2=Faxa_ndep, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
-
   end subroutine datm_datamode_simple_init_pointers
 
   !===============================================================================
@@ -319,7 +311,7 @@ contains
       ! long wave
       solar_decl = (epsilon_deg * degtorad) * sin( 2.0_R8 * shr_const_pi * (int(rday) + 284.0_R8) / 365.0_R8)
       zenith_angle = acos(sin(yc(n) * degtorad ) * sin(solar_decl) + cos(yc(n) * degtorad) * cos(solar_decl) )
-      Faxa_lwdn(n) = max(0.0_R8, peak_lwdn * cos(zenith_angle)) 
+      Faxa_lwdn(n) = max(0.0_R8, peak_lwdn * cos(zenith_angle))
 
       ! short wave
       hour_angle = (15.0_R8 * (target_tod/3600.0_R8 - 12.0_R8) + xc(n) ) * degtorad
@@ -331,11 +323,6 @@ contains
       Faxa_swndf(n) = Faxa_swnet(n)*(0.17_R8)
 
     enddo   ! lsize
-
-    if (associated(Faxa_ndep)) then
-       ! convert ndep flux to units of kgN/m2/s (input is in gN/m2/s)
-       Faxa_ndep(:,:) = Faxa_ndep(:,:) / 1000._r8
-    end if
 
   end subroutine datm_datamode_simple_advance
 

--- a/datm/datm_pres_aero_mod.F90
+++ b/datm/datm_pres_aero_mod.F90
@@ -1,0 +1,204 @@
+module datm_pres_aero_mod
+
+  use ESMF             , only : ESMF_SUCCESS, ESMF_State
+  use shr_kind_mod     , only : r8=>shr_kind_r8
+  use shr_log_mod      , only : shr_log_error
+  use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
+  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
+  use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
+
+  implicit none
+  private ! except
+
+  public :: datm_pres_aero_advertise
+  public :: datm_pres_aero_init_pointers
+  public :: datm_pres_aero_advance
+
+  ! pointers to export state data
+  real(r8), pointer :: Faxa_bcph(:,:)   => null()
+  real(r8), pointer :: Faxa_ocph(:,:)   => null()
+  real(r8), pointer :: Faxa_dstwet(:,:) => null()
+  real(r8), pointer :: Faxa_dstdry(:,:) => null()
+
+  ! pointers to stream data
+  real(r8), pointer :: strm_bcphidry(:) => null()
+  real(r8), pointer :: strm_bcphodry(:) => null()
+  real(r8), pointer :: strm_bcphiwet(:) => null()
+
+  real(r8), pointer :: strm_ocphidry(:) => null()
+  real(r8), pointer :: strm_ocphodry(:) => null()
+  real(r8), pointer :: strm_ocphiwet(:) => null()
+
+  real(r8), pointer :: strm_dstwet1(:)  => null()
+  real(r8), pointer :: strm_dstwet2(:)  => null()
+  real(r8), pointer :: strm_dstwet3(:)  => null()
+  real(r8), pointer :: strm_dstwet4(:)  => null()
+
+  real(r8), pointer :: strm_dstdry1(:)  => null()
+  real(r8), pointer :: strm_dstdry2(:)  => null()
+  real(r8), pointer :: strm_dstdry3(:)  => null()
+  real(r8), pointer :: strm_dstdry4(:)  => null()
+
+  character(*), parameter :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine datm_pres_aero_advertise(fldsExport)
+
+    ! input/output variables
+    type(fldlist_type) , pointer :: fldsexport
+    !----------------------------------------------------------
+
+    call dshr_fldList_add(fldsExport, 'Faxa_bcph'  , ungridded_lbound=1, ungridded_ubound=3)
+    call dshr_fldList_add(fldsExport, 'Faxa_ocph'  , ungridded_lbound=1, ungridded_ubound=3)
+    call dshr_fldList_add(fldsExport, 'Faxa_dstwet', ungridded_lbound=1, ungridded_ubound=4)
+    call dshr_fldList_add(fldsExport, 'Faxa_dstdry', ungridded_lbound=1, ungridded_ubound=4)
+
+  end subroutine datm_pres_aero_advertise
+
+  !===============================================================================
+  subroutine datm_pres_aero_init_pointers(exportState, sdat, rc)
+
+    ! input/output variables
+    type(ESMF_State)       , intent(inout) :: exportState
+    type(shr_strdata_type) , intent(in)    :: sdat
+    integer                , intent(out)   :: rc
+
+    ! local variables
+    character(len=*), parameter :: subname='(datm_pres_aero_init_pointers): '
+    !----------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Set module pointers into export state
+
+    call dshr_state_getfldptr(exportState, 'Faxa_bcph', fldptr2=Faxa_bcph, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_ocph', fldptr2=Faxa_ocph, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_dstwet', fldptr2=Faxa_dstwet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_state_getfldptr(exportState, 'Faxa_dstdry', fldptr2=Faxa_dstdry, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Set module pointers into streams and check that they are associated
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphidry' , strm_bcphidry, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphodry' , strm_bcphodry, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphiwet' , strm_bcphiwet, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphidry' , strm_ocphidry, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphodry' , strm_ocphodry, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphiwet' , strm_ocphiwet, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry1'  , strm_dstdry1 , rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry2'  , strm_dstdry2 , rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry3'  , strm_dstdry3 , rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry4'  , strm_dstdry4 , rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet1'  , strm_dstwet1 , rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet2'  , strm_dstwet2 , rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet3'  , strm_dstwet3 , rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet4'  , strm_dstwet4 , rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! error check for stream pointers
+    if (.not. associated(strm_bcphidry)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_bcphidry must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_bcphodry)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_bcphodry must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_bcphiwet)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_bcphiwet must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_ocphidry)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_ocphidry must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_ocphodry)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_ocphodry must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_ocphiwet)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_ocphiwet must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_dstdry1)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_dstdry1 must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_dstdry2)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_dstdry2 must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_dstdry3)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_dstdry3 must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_dstdry4)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_dstdry4 must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_dstwet1)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_dstwet1 must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_dstwet2)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_dstwet2 must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_dstwet3)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_dstwet3 must be associated if flds_presaero is .true.')
+       return
+    end if
+    if (.not. associated(strm_dstwet4)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_dstwet4 must be associated if flds_presaero is .true.')
+       return
+    end if
+
+  end subroutine datm_pres_aero_init_pointers
+
+  !===============================================================================
+  subroutine datm_pres_aero_advance()
+
+    ! The following maps stream input fields to export fields that
+    ! have an ungridded dimension
+
+    Faxa_bcph(1,:) = strm_bcphidry(:) 
+    Faxa_bcph(2,:) = strm_bcphodry(:) 
+    Faxa_bcph(3,:) = strm_bcphiwet(:)
+
+    Faxa_ocph(1,:) = strm_ocphidry(:) 
+    Faxa_ocph(2,:) = strm_ocphodry(:) 
+    Faxa_ocph(3,:) = strm_ocphiwet(:) 
+
+    Faxa_dstdry(1,:) = strm_dstdry1(:)
+    Faxa_dstdry(2,:) = strm_dstdry2(:)
+    Faxa_dstdry(3,:) = strm_dstdry3(:)
+    Faxa_dstdry(4,:) = strm_dstdry4(:)
+
+    Faxa_dstwet(1,:) = strm_dstwet1(:)
+    Faxa_dstwet(2,:) = strm_dstwet2(:)
+    Faxa_dstwet(3,:) = strm_dstwet3(:)
+    Faxa_dstwet(4,:) = strm_dstwet4(:)
+
+  end subroutine datm_pres_aero_advance
+
+end module datm_pres_aero_mod

--- a/datm/datm_pres_aero_mod.F90
+++ b/datm/datm_pres_aero_mod.F90
@@ -21,23 +21,23 @@ module datm_pres_aero_mod
   real(r8), pointer :: Faxa_dstdry(:,:) => null()
 
   ! pointers to stream data
-  real(r8), pointer :: strm_bcphidry(:) => null()
-  real(r8), pointer :: strm_bcphodry(:) => null()
-  real(r8), pointer :: strm_bcphiwet(:) => null()
+  real(r8), pointer :: strm_Faxa_bcphidry(:) => null()
+  real(r8), pointer :: strm_Faxa_bcphiwet(:) => null()
+  real(r8), pointer :: strm_Faxa_bcphodry(:) => null()
 
-  real(r8), pointer :: strm_ocphidry(:) => null()
-  real(r8), pointer :: strm_ocphodry(:) => null()
-  real(r8), pointer :: strm_ocphiwet(:) => null()
+  real(r8), pointer :: strm_Faxa_ocphidry(:) => null()
+  real(r8), pointer :: strm_Faxa_ocphiwet(:) => null()
+  real(r8), pointer :: strm_Faxa_ocphodry(:) => null()
 
-  real(r8), pointer :: strm_dstwet1(:)  => null()
-  real(r8), pointer :: strm_dstwet2(:)  => null()
-  real(r8), pointer :: strm_dstwet3(:)  => null()
-  real(r8), pointer :: strm_dstwet4(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstwet1(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstwet2(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstwet3(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstwet4(:)  => null()
 
-  real(r8), pointer :: strm_dstdry1(:)  => null()
-  real(r8), pointer :: strm_dstdry2(:)  => null()
-  real(r8), pointer :: strm_dstdry3(:)  => null()
-  real(r8), pointer :: strm_dstdry4(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstdry1(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstdry2(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstdry3(:)  => null()
+  real(r8), pointer :: strm_Faxa_dstdry4(:)  => null()
 
   character(*), parameter :: u_FILE_u = &
        __FILE__
@@ -86,90 +86,90 @@ contains
 
     ! Set module pointers into streams and check that they are associated
 
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphidry' , strm_bcphidry, rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphidry' , strm_Faxa_bcphidry, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphodry' , strm_bcphodry, rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphodry' , strm_Faxa_bcphodry, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphiwet' , strm_bcphiwet, rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphiwet' , strm_Faxa_bcphiwet, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphidry' , strm_ocphidry, rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphidry' , strm_Faxa_ocphidry, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphodry' , strm_ocphodry, rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphodry' , strm_Faxa_ocphodry, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphiwet' , strm_ocphiwet, rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphiwet' , strm_Faxa_ocphiwet, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry1'  , strm_dstdry1 , rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry1'  , strm_Faxa_dstdry1 , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry2'  , strm_dstdry2 , rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry2'  , strm_Faxa_dstdry2 , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry3'  , strm_dstdry3 , rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry3'  , strm_Faxa_dstdry3 , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry4'  , strm_dstdry4 , rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry4'  , strm_Faxa_dstdry4 , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet1'  , strm_dstwet1 , rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet1'  , strm_Faxa_dstwet1 , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet2'  , strm_dstwet2 , rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet2'  , strm_Faxa_dstwet2 , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet3'  , strm_dstwet3 , rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet3'  , strm_Faxa_dstwet3 , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet4'  , strm_dstwet4 , rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet4'  , strm_Faxa_dstwet4 , rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! error check for stream pointers
-    if (.not. associated(strm_bcphidry)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_bcphidry must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_bcphidry)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_bcphidry must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_bcphodry)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_bcphodry must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_bcphodry)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_bcphodry must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_bcphiwet)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_bcphiwet must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_bcphiwet)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_bcphiwet must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_ocphidry)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_ocphidry must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_ocphidry)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_ocphidry must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_ocphodry)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_ocphodry must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_ocphodry)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_ocphodry must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_ocphiwet)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_ocphiwet must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_ocphiwet)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_ocphiwet must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_dstdry1)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_dstdry1 must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_dstdry1)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstdry1 must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_dstdry2)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_dstdry2 must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_dstdry2)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstdry2 must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_dstdry3)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_dstdry3 must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_dstdry3)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstdry3 must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_dstdry4)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_dstdry4 must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_dstdry4)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstdry4 must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_dstwet1)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_dstwet1 must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_dstwet1)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstwet1 must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_dstwet2)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_dstwet2 must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_dstwet2)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstwet2 must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_dstwet3)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_dstwet3 must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_dstwet3)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstwet3 must be associated if flds_presaero is .true.')
        return
     end if
-    if (.not. associated(strm_dstwet4)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_dstwet4 must be associated if flds_presaero is .true.')
+    if (.not. associated(strm_Faxa_dstwet4)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstwet4 must be associated if flds_presaero is .true.')
        return
     end if
 
@@ -181,23 +181,23 @@ contains
     ! The following maps stream input fields to export fields that
     ! have an ungridded dimension
 
-    Faxa_bcph(1,:) = strm_bcphidry(:) 
-    Faxa_bcph(2,:) = strm_bcphodry(:) 
-    Faxa_bcph(3,:) = strm_bcphiwet(:)
+    Faxa_bcph(1,:) = strm_Faxa_bcphidry(:)
+    Faxa_bcph(2,:) = strm_Faxa_bcphodry(:)
+    Faxa_bcph(3,:) = strm_Faxa_bcphiwet(:)
 
-    Faxa_ocph(1,:) = strm_ocphidry(:) 
-    Faxa_ocph(2,:) = strm_ocphodry(:) 
-    Faxa_ocph(3,:) = strm_ocphiwet(:) 
+    Faxa_ocph(1,:) = strm_Faxa_ocphidry(:)
+    Faxa_ocph(2,:) = strm_Faxa_ocphodry(:)
+    Faxa_ocph(3,:) = strm_Faxa_ocphiwet(:)
 
-    Faxa_dstdry(1,:) = strm_dstdry1(:)
-    Faxa_dstdry(2,:) = strm_dstdry2(:)
-    Faxa_dstdry(3,:) = strm_dstdry3(:)
-    Faxa_dstdry(4,:) = strm_dstdry4(:)
+    Faxa_dstdry(1,:) = strm_Faxa_dstdry1(:)
+    Faxa_dstdry(2,:) = strm_Faxa_dstdry2(:)
+    Faxa_dstdry(3,:) = strm_Faxa_dstdry3(:)
+    Faxa_dstdry(4,:) = strm_Faxa_dstdry4(:)
 
-    Faxa_dstwet(1,:) = strm_dstwet1(:)
-    Faxa_dstwet(2,:) = strm_dstwet2(:)
-    Faxa_dstwet(3,:) = strm_dstwet3(:)
-    Faxa_dstwet(4,:) = strm_dstwet4(:)
+    Faxa_dstwet(1,:) = strm_Faxa_dstwet1(:)
+    Faxa_dstwet(2,:) = strm_Faxa_dstwet2(:)
+    Faxa_dstwet(3,:) = strm_Faxa_dstwet3(:)
+    Faxa_dstwet(4,:) = strm_Faxa_dstwet4(:)
 
   end subroutine datm_pres_aero_advance
 

--- a/datm/datm_pres_aero_mod.F90
+++ b/datm/datm_pres_aero_mod.F90
@@ -7,7 +7,7 @@ module datm_pres_aero_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public :: datm_pres_aero_advertise
   public :: datm_pres_aero_init_pointers
@@ -38,7 +38,7 @@ module datm_pres_aero_mod
   real(r8), pointer :: strm_Faxa_dstdry3(:)  => null()
   real(r8), pointer :: strm_Faxa_dstdry4(:)  => null()
 
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
@@ -86,59 +86,59 @@ contains
     ! Set module pointers into streams and check that they are associated
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphidry' , strm_Faxa_bcphidry, requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_bcphidry must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_bcphidry must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphodry' , strm_Faxa_bcphodry, requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_bcphodry must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_bcphodry must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphiwet' , strm_Faxa_bcphiwet, requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_bcphiwet must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_bcphiwet must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphidry' , strm_Faxa_ocphidry, requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_ocphidry must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_ocphidry must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphodry' , strm_Faxa_ocphodry, requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_ocphodry must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_ocphodry must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphiwet' , strm_Faxa_ocphiwet, requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_ocphiwet must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_ocphiwet must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry1'  , strm_Faxa_dstdry1 , requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_dstdry1 must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_dstdry1 must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry2'  , strm_Faxa_dstdry2 , requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_dstdry2 must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_dstdry2 must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry3'  , strm_Faxa_dstdry3 , requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_dstdry3 must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_dstdry3 must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry4'  , strm_Faxa_dstdry4 , requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_dstdry4 must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_dstdry4 must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet1'  , strm_Faxa_dstwet1 , requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_dstwet1 must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_dstwet1 must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet2'  , strm_Faxa_dstwet2 , requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_dstwet2 must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_dstwet2 must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet3'  , strm_Faxa_dstwet3 , requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_dstwet3 must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_dstwet3 must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet4'  , strm_Faxa_dstwet4 , requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Faxa_dstwet4 must be associated if flds_presaero is .true.', rc=rc)
+         errmsg=subname//'strm_Faxa_dstwet4 must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine datm_pres_aero_init_pointers

--- a/datm/datm_pres_aero_mod.F90
+++ b/datm/datm_pres_aero_mod.F90
@@ -2,7 +2,6 @@ module datm_pres_aero_mod
 
   use ESMF             , only : ESMF_SUCCESS, ESMF_State
   use shr_kind_mod     , only : r8=>shr_kind_r8
-  use shr_log_mod      , only : shr_log_error
   use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
@@ -86,92 +85,61 @@ contains
 
     ! Set module pointers into streams and check that they are associated
 
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphidry' , strm_Faxa_bcphidry, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphodry' , strm_Faxa_bcphodry, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphiwet' , strm_Faxa_bcphiwet, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphidry' , strm_Faxa_ocphidry, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphodry' , strm_Faxa_ocphodry, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphiwet' , strm_Faxa_ocphiwet, rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry1'  , strm_Faxa_dstdry1 , rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry2'  , strm_Faxa_dstdry2 , rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry3'  , strm_Faxa_dstdry3 , rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry4'  , strm_Faxa_dstdry4 , rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet1'  , strm_Faxa_dstwet1 , rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet2'  , strm_Faxa_dstwet2 , rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet3'  , strm_Faxa_dstwet3 , rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet4'  , strm_Faxa_dstwet4 , rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphidry' , strm_Faxa_bcphidry, requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_bcphidry must be associated if flds_presaero is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! error check for stream pointers
-    if (.not. associated(strm_Faxa_bcphidry)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_bcphidry must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_bcphodry)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_bcphodry must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_bcphiwet)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_bcphiwet must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_ocphidry)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_ocphidry must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_ocphodry)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_ocphodry must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_ocphiwet)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_ocphiwet must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_dstdry1)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstdry1 must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_dstdry2)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstdry2 must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_dstdry3)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstdry3 must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_dstdry4)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstdry4 must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_dstwet1)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstwet1 must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_dstwet2)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstwet2 must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_dstwet3)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstwet3 must be associated if flds_presaero is .true.')
-       return
-    end if
-    if (.not. associated(strm_Faxa_dstwet4)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Faxa_dstwet4 must be associated if flds_presaero is .true.')
-       return
-    end if
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphodry' , strm_Faxa_bcphodry, requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_bcphodry must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_bcphiwet' , strm_Faxa_bcphiwet, requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_bcphiwet must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphidry' , strm_Faxa_ocphidry, requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_ocphidry must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphodry' , strm_Faxa_ocphodry, requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_ocphodry must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ocphiwet' , strm_Faxa_ocphiwet, requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_ocphiwet must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry1'  , strm_Faxa_dstdry1 , requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_dstdry1 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry2'  , strm_Faxa_dstdry2 , requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_dstdry2 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry3'  , strm_Faxa_dstdry3 , requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_dstdry3 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstdry4'  , strm_Faxa_dstdry4 , requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_dstdry4 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet1'  , strm_Faxa_dstwet1 , requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_dstwet1 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet2'  , strm_Faxa_dstwet2 , requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_dstwet2 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet3'  , strm_Faxa_dstwet3 , requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_dstwet3 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_dstwet4'  , strm_Faxa_dstwet4 , requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Faxa_dstwet4 must be associated if flds_presaero is .true.', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine datm_pres_aero_init_pointers
 

--- a/datm/datm_pres_co2_mod.F90
+++ b/datm/datm_pres_co2_mod.F90
@@ -1,9 +1,7 @@
 module datm_pres_co2_mod
 
-  use ESMF             , only : ESMF_SUCCESS, ESMF_State, ESMF_StateItem_Flag
-  use ESMF             , only : ESMF_STATEITEM_NOTFOUND
+  use ESMF             , only : ESMF_SUCCESS, ESMF_State
   use shr_kind_mod     , only : r8=>shr_kind_r8, cl=>shr_kind_cl
-  use shr_log_mod      , only : shr_log_error
   use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
@@ -64,29 +62,21 @@ contains
     ! Get pointer to export state
     call dshr_state_getfldptr(exportState, 'Sa_co2diag', fldptr1=Sa_co2diag, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (.not. associated(Sa_co2diag)) then
-       call shr_log_error(trim(subname)//'ERROR: Sa_co2diag must be associated if flds_co2 is .true.')
-    end if
+
     call dshr_state_getfldptr(exportState, 'Sa_co2prog', fldptr1=Sa_co2prog, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (.not. associated(Sa_co2prog)) then
-       call shr_log_error(trim(subname)//'ERROR: Sa_co2prog must be associated if flds_co2 is .true.')
-       return
-    end if
 
     ! Get pointer to stream data that will be used below - if the
     ! following stream fields are not in any sdat streams, then a null value is returned
-    call shr_strdata_get_stream_pointer(sdat, 'Sa_co2diag', strm_Sa_co2diag, rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_co2diag', strm_Sa_co2diag, requirePointer=.true., &
+         errmsg=trim(subname)//'strm_Sa_co2diag must be associated if flds_co2 is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    if (.not. associated(strm_Sa_co2diag)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Sa_co2diag must be associated if flds_co2 is .true.')
-    end if
+
     if (datamode == 'CPLHIST') then
-       call shr_strdata_get_stream_pointer(sdat, 'Sa_co2prog', strm_Sa_co2prog, rc)
-       if (.not. associated(strm_Sa_co2prog)) then
-          call shr_log_error(trim(subname)//'ERROR: strm_Sa_co2prog must be associated if flds_co2 is .true.')
-          return
-       end if
+       call shr_strdata_get_stream_pointer(sdat, 'Sa_co2prog', strm_Sa_co2prog, requirePointer=.true., &
+            errmsg=trim(subname)//'strm_Sa_co2prog must be associated if flds_co2 is .true. '// &
+            ' and datamode is CPLHIST', rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
   end subroutine datm_pres_co2_init_pointers

--- a/datm/datm_pres_co2_mod.F90
+++ b/datm/datm_pres_co2_mod.F90
@@ -7,7 +7,7 @@ module datm_pres_co2_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public :: datm_pres_co2_advertise
   public :: datm_pres_co2_init_pointers
@@ -23,7 +23,7 @@ module datm_pres_co2_mod
 
   character(len=CL) :: datamode
 
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
@@ -66,15 +66,14 @@ contains
     call dshr_state_getfldptr(exportState, 'Sa_co2prog', fldptr1=Sa_co2prog, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! Get pointer to stream data that will be used below - if the
-    ! following stream fields are not in any sdat streams, then a null value is returned
+    ! Get pointer to stream data that will be used below
     call shr_strdata_get_stream_pointer(sdat, 'Sa_co2diag', strm_Sa_co2diag, requirePointer=.true., &
-         errmsg=trim(subname)//'strm_Sa_co2diag must be associated if flds_co2 is .true.', rc=rc)
+         errmsg=subname//'strm_Sa_co2diag must be associated if flds_co2 is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (datamode == 'CPLHIST') then
        call shr_strdata_get_stream_pointer(sdat, 'Sa_co2prog', strm_Sa_co2prog, requirePointer=.true., &
-            errmsg=trim(subname)//'strm_Sa_co2prog must be associated if flds_co2 is .true. '// &
+            errmsg=subname//'strm_Sa_co2prog must be associated if flds_co2 is .true. '// &
             ' and datamode is CPLHIST', rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
@@ -88,8 +87,8 @@ contains
        Sa_co2diag(:) = strm_Sa_co2diag(:)
        Sa_co2prog(:) = strm_Sa_co2prog(:)
     else
-       ! This is intentional since we don't have any Sa_co2prog - but for now
-       ! will set Sa_co2prog equal to Sa_co2diag
+       ! Because we do not currently have any Sa_co2prog in this case,
+       ! for now set Sa_co2prog equal to Sa_co2diag
        Sa_co2diag(:) = strm_Sa_co2diag(:)
        Sa_co2prog(:) = strm_Sa_co2diag(:)
     end if

--- a/datm/datm_pres_co2_mod.F90
+++ b/datm/datm_pres_co2_mod.F90
@@ -1,0 +1,109 @@
+module datm_pres_co2_mod
+
+  use ESMF             , only : ESMF_SUCCESS, ESMF_State, ESMF_StateItem_Flag
+  use ESMF             , only : ESMF_STATEITEM_NOTFOUND
+  use shr_kind_mod     , only : r8=>shr_kind_r8, cl=>shr_kind_cl
+  use shr_log_mod      , only : shr_log_error
+  use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
+  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
+  use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
+
+  implicit none
+  private ! except
+
+  public :: datm_pres_co2_advertise
+  public :: datm_pres_co2_init_pointers
+  public :: datm_pres_co2_advance
+
+  ! export state data
+  real(r8), pointer :: Sa_co2diag(:) => null()
+  real(r8), pointer :: Sa_co2prog(:) => null()
+
+  ! stream pointer
+  real(r8), pointer :: strm_Sa_co2diag(:) => null()
+  real(r8), pointer :: strm_Sa_co2prog(:) => null()
+
+  character(len=CL) :: datamode
+
+  character(*), parameter :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine datm_pres_co2_advertise(fldsExport, datamode_in)
+
+    ! input/output variables
+    type(fldlist_type) , pointer    :: fldsexport
+    character(len=*)   , intent(in) :: datamode_in
+    !----------------------------------------------------------
+
+    ! Set module variable
+    datamode = datamode_in
+
+    call dshr_fldList_add(fldsExport, 'Sa_co2diag')
+    call dshr_fldList_add(fldsExport, 'Sa_co2prog')
+
+  end subroutine datm_pres_co2_advertise
+
+  !===============================================================================
+  subroutine datm_pres_co2_init_pointers(exportState, sdat, rc)
+
+    ! input/output variables
+    type(ESMF_State)       , intent(inout) :: exportState
+    type(shr_strdata_type) , intent(in)    :: sdat
+    integer                , intent(out)   :: rc
+
+    ! local variables
+    character(len=*), parameter :: subname='(datm_pres_co2_init_pointers): '
+    !----------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Get pointer to export state
+    call dshr_state_getfldptr(exportState, 'Sa_co2diag', fldptr1=Sa_co2diag, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (.not. associated(Sa_co2diag)) then
+       call shr_log_error(trim(subname)//'ERROR: Sa_co2diag must be associated if flds_co2 is .true.')
+    end if
+    call dshr_state_getfldptr(exportState, 'Sa_co2prog', fldptr1=Sa_co2prog, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (.not. associated(Sa_co2prog)) then
+       call shr_log_error(trim(subname)//'ERROR: Sa_co2prog must be associated if flds_co2 is .true.')
+       return
+    end if
+
+    ! Get pointer to stream data that will be used below - if the
+    ! following stream fields are not in any sdat streams, then a null value is returned
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_co2diag', strm_Sa_co2diag, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (.not. associated(strm_Sa_co2diag)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Sa_co2diag must be associated if flds_co2 is .true.')
+    end if
+    if (datamode == 'CPLHIST') then
+       call shr_strdata_get_stream_pointer(sdat, 'Sa_co2prog', strm_Sa_co2prog, rc)
+       if (.not. associated(strm_Sa_co2prog)) then
+          call shr_log_error(trim(subname)//'ERROR: strm_Sa_co2prog must be associated if flds_co2 is .true.')
+          return
+       end if
+    end if
+
+  end subroutine datm_pres_co2_init_pointers
+
+  !===============================================================================
+  subroutine datm_pres_co2_advance()
+
+    if (datamode == 'CPLHIST') then
+       Sa_co2diag(:) = strm_Sa_co2diag(:)
+       Sa_co2prog(:) = strm_Sa_co2prog(:)
+    else
+       ! This is intentional since we don't have any Sa_co2prog - but for now
+       ! will set Sa_co2prog equal to Sa_co2diag
+       Sa_co2diag(:) = strm_Sa_co2diag(:)
+       Sa_co2prog(:) = strm_Sa_co2diag(:)
+    end if
+
+  end subroutine datm_pres_co2_advance
+
+end module datm_pres_co2_mod

--- a/datm/datm_pres_ndep_mod.F90
+++ b/datm/datm_pres_ndep_mod.F90
@@ -1,0 +1,113 @@
+module datm_pres_ndep_mod
+
+  use ESMF             , only : ESMF_SUCCESS, ESMF_State, ESMF_StateItem_Flag
+  use shr_kind_mod     , only : r8=>shr_kind_r8
+  use shr_log_mod      , only : shr_log_error
+  use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
+  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
+  use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
+
+  implicit none
+  private ! except
+
+  public :: datm_pres_ndep_advertise
+  public :: datm_pres_ndep_init_pointers
+  public :: datm_pres_ndep_advance
+
+  ! export state data
+  real(r8), pointer :: Faxa_ndep(:,:) => null()
+
+  ! stream data
+  real(r8), pointer :: strm_ndep_nhx_dry(:) => null() ! stream cmip7 ndep data
+  real(r8), pointer :: strm_ndep_nhx_wet(:) => null() ! stream cmip7 ndep data
+  real(r8), pointer :: strm_ndep_noy_dry(:) => null() ! stream cmip7 ndep data
+  real(r8), pointer :: strm_ndep_noy_wet(:) => null() ! stream cmip7 ndep data
+
+  real(r8), pointer :: strm_ndep_nhx(:)     => null() ! pre-cmip7 ndep data
+  real(r8), pointer :: strm_ndep_noy(:)     => null() ! pre-cmip7 ndep data
+
+  logical :: use_cmip7_ndep
+
+  character(*), parameter :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine datm_pres_ndep_advertise(fldsExport)
+
+    ! input/output variables
+    type(fldlist_type) , pointer :: fldsexport
+    !----------------------------------------------------------
+
+    call dshr_fldList_add(fldsExport, 'Faxa_ndep', ungridded_lbound=1, ungridded_ubound=2)
+
+  end subroutine datm_pres_ndep_advertise
+
+  !===============================================================================
+  subroutine datm_pres_ndep_init_pointers(exportState, sdat, rc)
+
+    ! input/output variables
+    type(ESMF_State)       , intent(inout) :: exportState
+    type(shr_strdata_type) , intent(in)    :: sdat
+    integer                , intent(out)   :: rc
+
+    ! local variables
+    character(len=*), parameter :: subname='(datm_ndep_init_pointers): '
+    !----------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Get pointer to export state
+    call dshr_state_getfldptr(exportState, 'Faxa_ndep', fldptr2=Faxa_ndep, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Get pointer to stream data that will be used below - if the
+    ! following stream fields are not in any sdat streams, then a null value is returned
+
+    ! cmip7 forcing
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_nhx_dry', strm_ndep_nhx_dry, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_nhx_wet', strm_ndep_nhx_wet, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_noy_dry', strm_ndep_noy_dry, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_noy_wet', strm_ndep_noy_wet, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! older ndep forcing
+    call shr_strdata_get_stream_pointer( sdat, 'Faxa_ndep_nhx', strm_ndep_nhx, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_strdata_get_stream_pointer( sdat, 'Faxa_ndep_noy', strm_ndep_noy, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! error checks
+    if (associated(strm_ndep_nhx_dry) .and. associated(strm_ndep_nhx_wet) .and. &
+        associated(strm_ndep_noy_dry) .and. associated(strm_ndep_noy_wet)) then
+       use_cmip7_ndep = .true.
+    else if (associated(strm_ndep_nhx) .and. associated(strm_ndep_noy)) then
+       use_cmip7_ndep = .false.
+    else
+       call shr_log_error('datm_ndep_advance: ERROR: no associated stream pointers for ndep forcing')
+       return
+    end if
+
+  end subroutine datm_pres_ndep_init_pointers
+
+  !===============================================================================
+  subroutine datm_pres_ndep_advance()
+
+    if (use_cmip7_ndep) then
+       ! assume data is in kgN/m2/s
+       Faxa_ndep(1,:) = strm_ndep_nhx_dry(:) + strm_ndep_nhx_wet(:)
+       Faxa_ndep(2,:) = strm_ndep_noy_dry(:) + strm_ndep_noy_wet(:)
+    else
+       ! convert ndep flux to units of kgN/m2/s (input is in gN/m2/s)
+       Faxa_ndep(1,:) = strm_ndep_nhx(:) / 1000._r8
+       Faxa_ndep(2,:) = strm_ndep_noy(:) / 1000._r8
+    end if
+
+  end subroutine datm_pres_ndep_advance
+
+end module datm_pres_ndep_mod

--- a/datm/datm_pres_ndep_mod.F90
+++ b/datm/datm_pres_ndep_mod.F90
@@ -18,13 +18,13 @@ module datm_pres_ndep_mod
   real(r8), pointer :: Faxa_ndep(:,:) => null()
 
   ! stream data
-  real(r8), pointer :: strm_ndep_nhx_dry(:) => null() ! stream cmip7 ndep data
-  real(r8), pointer :: strm_ndep_nhx_wet(:) => null() ! stream cmip7 ndep data
-  real(r8), pointer :: strm_ndep_noy_dry(:) => null() ! stream cmip7 ndep data
-  real(r8), pointer :: strm_ndep_noy_wet(:) => null() ! stream cmip7 ndep data
+  real(r8), pointer :: strm_Faxa_ndep_nhx_dry(:) => null() ! stream cmip7 ndep data
+  real(r8), pointer :: strm_Faxa_ndep_nhx_wet(:) => null() ! stream cmip7 ndep data
+  real(r8), pointer :: strm_Faxa_ndep_noy_dry(:) => null() ! stream cmip7 ndep data
+  real(r8), pointer :: strm_Faxa_ndep_noy_wet(:) => null() ! stream cmip7 ndep data
 
-  real(r8), pointer :: strm_ndep_nhx(:)     => null() ! pre-cmip7 ndep data
-  real(r8), pointer :: strm_ndep_noy(:)     => null() ! pre-cmip7 ndep data
+  real(r8), pointer :: strm_Faxa_ndep_nhx(:)     => null() ! pre-cmip7 ndep data
+  real(r8), pointer :: strm_Faxa_ndep_noy(:)     => null() ! pre-cmip7 ndep data
 
   logical :: use_cmip7_ndep
 
@@ -66,27 +66,27 @@ contains
     ! Get pointer to stream data that will be used below - if the
     ! following stream fields are not in any sdat streams, then a null value is returned
 
-    ! cmip7 forcing
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_nhx_dry', strm_ndep_nhx_dry, rc)
+    ! cmip7 ndep forcing
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_nhx_dry', strm_Faxa_ndep_nhx_dry, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_nhx_wet', strm_ndep_nhx_wet, rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_nhx_wet', strm_Faxa_ndep_nhx_wet, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_noy_dry', strm_ndep_noy_dry, rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_noy_dry', strm_Faxa_ndep_noy_dry, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_noy_wet', strm_ndep_noy_wet, rc)
+    call shr_strdata_get_stream_pointer(sdat, 'Faxa_ndep_noy_wet', strm_Faxa_ndep_noy_wet, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! older ndep forcing
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_ndep_nhx', strm_ndep_nhx, rc)
+    ! cmip6 ndep forcing
+    call shr_strdata_get_stream_pointer( sdat, 'Faxa_ndep_nhx', strm_Faxa_ndep_nhx, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_strdata_get_stream_pointer( sdat, 'Faxa_ndep_noy', strm_ndep_noy, rc)
+    call shr_strdata_get_stream_pointer( sdat, 'Faxa_ndep_noy', strm_Faxa_ndep_noy, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! determine use_cmip_ndep module variable
-    if (associated(strm_ndep_nhx_dry) .and. associated(strm_ndep_nhx_wet) .and. &
-        associated(strm_ndep_noy_dry) .and. associated(strm_ndep_noy_wet)) then
+    if (associated(strm_Faxa_ndep_nhx_dry) .and. associated(strm_Faxa_ndep_nhx_wet) .and. &
+        associated(strm_Faxa_ndep_noy_dry) .and. associated(strm_Faxa_ndep_noy_wet)) then
        use_cmip7_ndep = .true.
-    else if (associated(strm_ndep_nhx) .and. associated(strm_ndep_noy)) then
+    else if (associated(strm_Faxa_ndep_nhx) .and. associated(strm_Faxa_ndep_noy)) then
        use_cmip7_ndep = .false.
     else
        call shr_log_error('datm_ndep_advance: ERROR: no associated stream pointers for ndep forcing', rc=rc)
@@ -100,12 +100,12 @@ contains
 
     if (use_cmip7_ndep) then
        ! assume data is in kgN/m2/s
-       Faxa_ndep(1,:) = strm_ndep_nhx_dry(:) + strm_ndep_nhx_wet(:)
-       Faxa_ndep(2,:) = strm_ndep_noy_dry(:) + strm_ndep_noy_wet(:)
+       Faxa_ndep(1,:) = strm_Faxa_ndep_nhx_dry(:) + strm_Faxa_ndep_nhx_wet(:)
+       Faxa_ndep(2,:) = strm_Faxa_ndep_noy_dry(:) + strm_Faxa_ndep_noy_wet(:)
     else
        ! convert ndep flux to units of kgN/m2/s (input is in gN/m2/s)
-       Faxa_ndep(1,:) = strm_ndep_nhx(:) / 1000._r8
-       Faxa_ndep(2,:) = strm_ndep_noy(:) / 1000._r8
+       Faxa_ndep(1,:) = strm_Faxa_ndep_nhx(:) / 1000._r8
+       Faxa_ndep(2,:) = strm_Faxa_ndep_noy(:) / 1000._r8
     end if
 
   end subroutine datm_pres_ndep_advance

--- a/datm/datm_pres_ndep_mod.F90
+++ b/datm/datm_pres_ndep_mod.F90
@@ -8,7 +8,7 @@ module datm_pres_ndep_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public :: datm_pres_ndep_advertise
   public :: datm_pres_ndep_init_pointers
@@ -28,7 +28,7 @@ module datm_pres_ndep_mod
 
   logical :: use_cmip7_ndep
 
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================

--- a/datm/datm_pres_ndep_mod.F90
+++ b/datm/datm_pres_ndep_mod.F90
@@ -82,14 +82,14 @@ contains
     call shr_strdata_get_stream_pointer( sdat, 'Faxa_ndep_noy', strm_ndep_noy, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! error checks
+    ! determine use_cmip_ndep module variable
     if (associated(strm_ndep_nhx_dry) .and. associated(strm_ndep_nhx_wet) .and. &
         associated(strm_ndep_noy_dry) .and. associated(strm_ndep_noy_wet)) then
        use_cmip7_ndep = .true.
     else if (associated(strm_ndep_nhx) .and. associated(strm_ndep_noy)) then
        use_cmip7_ndep = .false.
     else
-       call shr_log_error('datm_ndep_advance: ERROR: no associated stream pointers for ndep forcing')
+       call shr_log_error('datm_ndep_advance: ERROR: no associated stream pointers for ndep forcing', rc=rc)
        return
     end if
 

--- a/datm/datm_pres_o3_mod.F90
+++ b/datm/datm_pres_o3_mod.F90
@@ -7,7 +7,7 @@ module datm_pres_o3_mod
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
 
   implicit none
-  private ! except
+  private
 
   public :: datm_pres_o3_advertise
   public :: datm_pres_o3_init_pointers
@@ -19,7 +19,7 @@ module datm_pres_o3_mod
   ! stream pointer
   real(r8), pointer :: strm_Sa_o3(:) => null()
 
-  character(*), parameter :: u_FILE_u = &
+  character(len=*), parameter :: u_FILE_u = &
        __FILE__
 
 !===============================================================================
@@ -55,7 +55,7 @@ contains
 
     ! Get pointer to stream data that will be used below
     call shr_strdata_get_stream_pointer(sdat, 'Sa_o3', strm_Sa_o3, requirePointer=.true., &
-         errmsg=trim(subname)//'ERROR: strm_Sa_o3 must be associated if flds_pres_o3 is .true.', rc=rc)
+         errmsg=subname//'ERROR: strm_Sa_o3 must be associated if flds_pres_o3 is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine datm_pres_o3_init_pointers

--- a/datm/datm_pres_o3_mod.F90
+++ b/datm/datm_pres_o3_mod.F90
@@ -1,9 +1,7 @@
 module datm_pres_o3_mod
 
-  use ESMF             , only : ESMF_SUCCESS, ESMF_State, ESMF_StateItem_Flag
-  use ESMF             , only : ESMF_STATEITEM_NOTFOUND
+  use ESMF             , only : ESMF_SUCCESS, ESMF_State
   use shr_kind_mod     , only : r8=>shr_kind_r8
-  use shr_log_mod      , only : shr_log_error
   use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
   use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
@@ -55,16 +53,10 @@ contains
     call dshr_state_getfldptr(exportState, 'Sa_o3', fldptr1=Sa_o3, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! Get pointer to stream data that will be used below - if the
-    ! following stream fields are not in any sdat streams, then a null value is returned
-    call shr_strdata_get_stream_pointer(sdat, 'Sa_o3', strm_Sa_o3, rc)
+    ! Get pointer to stream data that will be used below
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_o3', strm_Sa_o3, requirePointer=.true., &
+         errmsg=trim(subname)//'ERROR: strm_Sa_o3 must be associated if flds_pres_o3 is .true.', rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-    ! Error checks
-    if (.not. associated(strm_Sa_o3)) then
-       call shr_log_error(trim(subname)//'ERROR: strm_Sa_o3 must be associated if flds_pres_o3 is .true.')
-       return
-    end if
 
   end subroutine datm_pres_o3_init_pointers
 

--- a/datm/datm_pres_o3_mod.F90
+++ b/datm/datm_pres_o3_mod.F90
@@ -1,0 +1,78 @@
+module datm_pres_o3_mod
+
+  use ESMF             , only : ESMF_SUCCESS, ESMF_State, ESMF_StateItem_Flag
+  use ESMF             , only : ESMF_STATEITEM_NOTFOUND
+  use shr_kind_mod     , only : r8=>shr_kind_r8
+  use shr_log_mod      , only : shr_log_error
+  use dshr_methods_mod , only : dshr_state_getfldptr, chkerr
+  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_get_stream_pointer
+  use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add
+
+  implicit none
+  private ! except
+
+  public :: datm_pres_o3_advertise
+  public :: datm_pres_o3_init_pointers
+  public :: datm_pres_o3_advance
+
+  ! export state data
+  real(r8), pointer :: Sa_o3(:) => null()
+
+  ! stream pointer
+  real(r8), pointer :: strm_Sa_o3(:) => null()
+
+  character(*), parameter :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine datm_pres_o3_advertise(fldsExport)
+
+    ! input/output variables
+    type(fldlist_type) , pointer :: fldsexport
+
+    call dshr_fldList_add(fldsExport, 'Sa_o3')
+
+  end subroutine datm_pres_o3_advertise
+
+  !===============================================================================
+  subroutine datm_pres_o3_init_pointers(exportState, sdat, rc)
+
+    ! input/output variables
+    type(ESMF_State)       , intent(inout) :: exportState
+    type(shr_strdata_type) , intent(in)    :: sdat
+    integer                , intent(out)   :: rc
+
+    ! local variables
+    character(len=*), parameter :: subname='(datm_o3_init_pointers): '
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Get pointer to export state
+    call dshr_state_getfldptr(exportState, 'Sa_o3', fldptr1=Sa_o3, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Get pointer to stream data that will be used below - if the
+    ! following stream fields are not in any sdat streams, then a null value is returned
+    call shr_strdata_get_stream_pointer(sdat, 'Sa_o3', strm_Sa_o3, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Error checks
+    if (.not. associated(strm_Sa_o3)) then
+       call shr_log_error(trim(subname)//'ERROR: strm_Sa_o3 must be associated if flds_pres_o3 is .true.')
+       return
+    end if
+
+  end subroutine datm_pres_o3_init_pointers
+
+  !===============================================================================
+  subroutine datm_pres_o3_advance()
+
+    Sa_o3(:) = strm_Sa_o3(:)
+
+  end subroutine datm_pres_o3_advance
+
+end module datm_pres_o3_mod

--- a/dglc/cime_config/namelist_definition_dglc.xml
+++ b/dglc/cime_config/namelist_definition_dglc.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <!--

--- a/dglc/cime_config/stream_definition_dglc.xml
+++ b/dglc/cime_config/stream_definition_dglc.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
   <!--
       %y   => year from the range yearfirst to yearlast
               obtained from values of <strm_year_start> -> <strm_year_end> below

--- a/dglc/cime_config/testdefs/testlist_dglc.xml
+++ b/dglc/cime_config/testdefs/testlist_dglc.xml
@@ -27,6 +27,14 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
+  <test compset="2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV" grid="f19_tn14_gris4" name="SMS_D_Ly3">
+    <machines>
+      <machine name="betzy" compiler="gnu" category="aux_cdeps_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:30:00 </option>
+    </options>
+  </test>
   <!-- NOTE: currently there is no compset DATAMODELTEST -->
   <!-- <test compset="DATAMODELTEST" grid="f10_f10_ais8gris4_mg37" name="SMS_D_Ld3"> -->
   <!--   <machines> -->

--- a/dglc/cime_config/testdefs/testlist_dglc.xml
+++ b/dglc/cime_config/testdefs/testlist_dglc.xml
@@ -22,6 +22,7 @@
   <test compset="2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV" grid="f19_g17_gris4" name="SMS_Ly3">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
+      <machine name="betzy" compiler="intel" category="aux_cdeps_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
@@ -31,7 +32,7 @@
   <test compset="DATAMODELTEST" grid="f10_f10_ais8gris4_mg37" name="SMS_D_Ld3">
     <machines>
       <machine name="derecho" compiler="gnu" category="aux_cdeps"/>
-      <machine name="derecho" compiler="gnu" category="aux_cdeps_noresm"/>
+      <machine name="betzy" compiler="gnu" category="aux_cdeps_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>

--- a/dglc/cime_config/testdefs/testlist_dglc.xml
+++ b/dglc/cime_config/testdefs/testlist_dglc.xml
@@ -22,30 +22,20 @@
   <test compset="2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV" grid="f19_g17_gris4" name="SMS_Ly3">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cdeps"/>
-      <machine name="betzy" compiler="intel" category="aux_cdeps_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-
-  <test compset="DATAMODELTEST" grid="f10_f10_ais8gris4_mg37" name="SMS_D_Ld3">
-    <machines>
-      <machine name="derecho" compiler="gnu" category="aux_cdeps"/>
-      <machine name="betzy" compiler="gnu" category="aux_cdeps_noresm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:10:00 </option>
-    </options>
-  </test>
-
-    <test compset="2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV" grid="f19_tn14_gris4" name="SMS_D_Ly3">
-    <machines>
-      <machine name="betzy" compiler="gnu" category="aux_cdeps_noresm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30:00 </option>
-    </options>
-  </test>
+  <!-- NOTE: currently there is no compset DATAMODELTEST -->
+  <!-- <test compset="DATAMODELTEST" grid="f10_f10_ais8gris4_mg37" name="SMS_D_Ld3"> -->
+  <!--   <machines> -->
+  <!--     <machine name="derecho" compiler="gnu" category="aux_cdeps"/> -->
+  <!--     <machine name="betzy" compiler="gnu" category="aux_cdeps_noresm"/> -->
+  <!--   </machines> -->
+  <!--   <options> -->
+  <!--     <option name="wallclock"> 00:10:00 </option> -->
+  <!--   </options> -->
+  <!-- </test> -->
 
 </testlist>

--- a/dglc/cime_config/testdefs/testlist_dglc.xml
+++ b/dglc/cime_config/testdefs/testlist_dglc.xml
@@ -27,14 +27,6 @@
       <option name="wallclock"> 00:10:00 </option>
     </options>
   </test>
-  <test compset="2000_SATM_SLND_SICE_SOCN_SROF_DGLC%NOEVOLVE_SWAV" grid="f19_tn14_gris4" name="SMS_D_Ly3">
-    <machines>
-      <machine name="betzy" compiler="gnu" category="aux_cdeps_noresm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30:00 </option>
-    </options>
-  </test>
   <!-- NOTE: currently there is no compset DATAMODELTEST -->
   <!-- <test compset="DATAMODELTEST" grid="f10_f10_ais8gris4_mg37" name="SMS_D_Ld3"> -->
   <!--   <machines> -->

--- a/dice/cime_config/namelist_definition_dice.xml
+++ b/dice/cime_config/namelist_definition_dice.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <!-- Values to use by default for creation of DICE model namelists.
@@ -54,7 +52,7 @@
     <desc>file specifying model mesh</desc>
     <values>
       <value>$ICE_DOMAIN_MESH</value>
-      <value single_column='true'>null</value> 
+      <value single_column='true'>null</value>
     </values>
   </entry>
 
@@ -68,7 +66,7 @@
     </desc>
     <values>
       <value>$MASK_MESH</value>
-      <value single_column='true'>null</value> 
+      <value single_column='true'>null</value>
     </values>
   </entry>
 
@@ -81,7 +79,7 @@
     </desc>
     <values>
       <value>$ICE_NX</value>
-      <value single_column='true'>1</value> 
+      <value single_column='true'>1</value>
     </values>
   </entry>
 
@@ -94,7 +92,7 @@
     </desc>
     <values>
       <value>$ICE_NY</value>
-      <value single_column='true'>1</value> 
+      <value single_column='true'>1</value>
     </values>
   </entry>
 

--- a/dice/cime_config/stream_definition_dice.xml
+++ b/dice/cime_config/stream_definition_dice.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <stream_data version="2.0" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <stream_entry name="ssmi_nyf">

--- a/dlnd/cime_config/config_component.xml
+++ b/dlnd/cime_config/config_component.xml
@@ -108,7 +108,7 @@
     </values>
     <group>run_component_dlnd</group>
     <file>env_run.xml</file>
-    <desc>starting year to loop data over (only used when DLND_MODE is CPLHIST or GLC_CPLHIST or ROF_CPLHIST)</desc>
+    <desc>starting year to loop data over (only used when DLND_MODE is SCPL or GCPL or RCPL)</desc>
   </entry>
 
   <entry id="DLND_CPLHIST_YR_END">
@@ -119,7 +119,7 @@
     </values>
     <group>run_component_dlnd</group>
     <file>env_run.xml</file>
-    <desc>ending year to loop data over (only used when DLND_MODE is CPLHIST or GLC_CPLHIST)</desc>
+    <desc>starting year to loop data over (only used when DLND_MODE is SCPL or GCPL or RCPL)</desc>
   </entry>
 
   <entry id="DLND_SKIP_RESTART_READ">

--- a/dlnd/cime_config/config_component.xml
+++ b/dlnd/cime_config/config_component.xml
@@ -52,18 +52,8 @@
     <default_value>none</default_value>
     <group>run_component_dlnd</group>
     <file>env_run.xml</file>
-    <desc>colon delimited string of non water tracers to be sent from dlnd to the mediator - only used for DLND%%RCPL</desc>
+    <desc>colon delimited string of non water tracers to be sent from dlnd to the mediator - only used for DLND%RCPL</desc>
   </entry>
-
-  <!-- <entry id="DLND_LND2ROF_NONH2O_NUMBER"> -->
-  <!--   <type>integer</type> -->
-  <!--   <default_value>0</default_value> -->
-  <!--   <group>run_component_dlnd</group> -->
-  <!--   <file>env_run.xml</file> -->
-  <!--   <desc>Number of liquid non-water lnd to rof tracers. This must be -->
-  <!--   consistent with DLND_LND2ROF_NONH2O and is currently -->
-  <!--   required by DLND to create the necessary stream field names.</desc> -->
-  <!-- </entry> -->
 
   <entry id="DLND_CPLHIST_DIR">
     <type>char</type>

--- a/dlnd/cime_config/config_component.xml
+++ b/dlnd/cime_config/config_component.xml
@@ -119,7 +119,7 @@
     </values>
     <group>run_component_dlnd</group>
     <file>env_run.xml</file>
-    <desc>starting year to loop data over (only used when DLND_MODE is SCPL or GCPL or RCPL)</desc>
+    <desc>ending year to loop data over (only used when DLND_MODE is SCPL or GCPL or RCPL)</desc>
   </entry>
 
   <entry id="DLND_SKIP_RESTART_READ">

--- a/dlnd/cime_config/namelist_definition_dlnd.xml
+++ b/dlnd/cime_config/namelist_definition_dlnd.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <!--

--- a/dlnd/cime_config/stream_definition_dlnd.xml
+++ b/dlnd/cime_config/stream_definition_dlnd.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
   <!--
       %glc => GLC elevation class from the range 0 to GLC_NEC, obtained from the GLC_NEC xml variable
       %y   => year from the range yearfirst to yearlast

--- a/dlnd/dlnd_datamode_rof_forcing_mod.F90
+++ b/dlnd/dlnd_datamode_rof_forcing_mod.F90
@@ -44,6 +44,9 @@ module dlnd_datamode_rof_forcing_mod
    real(r8), pointer :: strm_Flrl_irrig(:)  => null()
 
    integer :: ntracers_nonh2o
+
+   ! Note that setting the maximum value to 99 is due to the i2.2 format below
+   ! for generating the strm_fld field names
    integer, parameter :: ntracers_nonh2o_max = 99
 
    character(*), parameter :: nullstr = 'null'

--- a/dlnd/dlnd_datamode_rof_forcing_mod.F90
+++ b/dlnd/dlnd_datamode_rof_forcing_mod.F90
@@ -11,6 +11,7 @@ module dlnd_datamode_rof_forcing_mod
    use dshr_strdata_mod        , only : shr_strdata_type, shr_strdata_get_stream_pointer
    use dshr_fldlist_mod        , only : fldlist_type, dshr_fldlist_add
    use shr_lnd2rof_tracers_mod , only : shr_lnd2rof_tracers_readnl
+  use shr_strconvert_mod       , only : toString
 
    implicit none
    private ! except
@@ -43,6 +44,7 @@ module dlnd_datamode_rof_forcing_mod
    real(r8), pointer :: strm_Flrl_irrig(:)  => null()
 
    integer :: ntracers_nonh2o
+   integer, parameter :: ntracers_nonh2o_max = 99
 
    character(*), parameter :: nullstr = 'null'
    character(*), parameter :: u_FILE_u = &
@@ -81,9 +83,10 @@ contains
       call shr_lnd2rof_tracers_readnl('drv_flds_in', lnd2rof_tracers)
       if (lnd2rof_tracers /= ' ') then
          ntracers_nonh2o = shr_string_listGetNum(lnd2rof_tracers)
-         if (ntracers_nonh2o > 99) then
+         if (ntracers_nonh2o > ntracers_nonh2o_max) then
             rc = ESMF_FAILURE
-            call shr_log_error(subName//': ERROR: number of tracers must be less than 99', rc=rc)
+            call shr_log_error(subName//': ERROR: number of tracers must be less than '//&
+                 trim(toString(ntracers_nonh2o_max)), rc=rc)
             return
          end if
       else
@@ -146,12 +149,14 @@ contains
       call dshr_state_getfldptr(exportState, fldname='Sl_lfrin', fldptr1=lfrac, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
       lfrac(:) = model_frac(:) ! Set fractional land pointer in export state
-      if (ntracers_nonh2o > 1) then
-         call dshr_state_getfldptr(exportState, fldname='Flrl_rofsur_nonh2o', fldptr2=Flrl_rofsur_nonh2o_2d, rc=rc)
-         if (chkerr(rc,__LINE__,u_FILE_u)) return
-      else
-         call dshr_state_getfldptr(exportState, fldname='Flrl_rofsur_nonh2o', fldptr1=Flrl_rofsur_nonh2o_1d, rc=rc)
-         if (chkerr(rc,__LINE__,u_FILE_u)) return
+      if (ntracers_nonh2o > 0) then
+         if (ntracers_nonh2o > 1) then
+            call dshr_state_getfldptr(exportState, fldname='Flrl_rofsur_nonh2o', fldptr2=Flrl_rofsur_nonh2o_2d, rc=rc)
+            if (chkerr(rc,__LINE__,u_FILE_u)) return
+         else
+            call dshr_state_getfldptr(exportState, fldname='Flrl_rofsur_nonh2o', fldptr1=Flrl_rofsur_nonh2o_1d, rc=rc)
+            if (chkerr(rc,__LINE__,u_FILE_u)) return
+         end if
       end if
       call dshr_state_getfldptr(exportState, fldname='Flrl_rofsur', fldptr1=Flrl_rofsur, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -253,7 +258,7 @@ contains
       end do
 
       if (associated(strm_Flrl_irrig)) then
-         do ni = 1,size(Flrl_rofsur)
+         do ni = 1,size(Flrl_irrig)
             if (lfrac(ni) == 0._r8) then
                Flrl_irrig(ni)  = SHR_CONST_SPVAL
             else

--- a/dlnd/lnd_comp_nuopc.F90
+++ b/dlnd/lnd_comp_nuopc.F90
@@ -67,7 +67,7 @@ module cdeps_dlnd_comp
   integer                  :: flds_scalar_index_ny = 0
   integer                  :: mpicom                              ! mpi communicator
   integer                  :: my_task                             ! my task in mpi communicator mpicom
-  logical                  :: mainproc                            ! true of my_task == main_task
+  logical                  :: mainproc                            ! true if my_task == main_task
   integer                  :: inst_index                          ! number of current instance (ie. 1)
   character(len=16)        :: inst_suffix = ""                    ! char string associated with instance (ie. "_0001" or "")
   integer                  :: logunit                             ! logging unit number
@@ -460,6 +460,9 @@ contains
        case('rof_forcing')
           call dlnd_datamode_rof_forcing_init_pointers(exportState, sdat, model_frac, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       case default
+          call shr_log_error(' ERROR illegal dlnd datamode = '//trim(datamode), rc=rc)
+          return
        end select
 
        first_time = .false.
@@ -481,6 +484,9 @@ contains
        call dlnd_datamode_glc_forcing_advance()
     case('rof_forcing')
        call dlnd_datamode_rof_forcing_advance()
+    case default
+       call shr_log_error(' ERROR illegal dlnd datamode = '//trim(datamode), rc=rc)
+       return
     end select
 
     call ESMF_TraceRegionExit('DLND_RUN')

--- a/docn/cime_config/namelist_definition_docn.xml
+++ b/docn/cime_config/namelist_definition_docn.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <!-- Values to use by default for creation of DOCN model docn namelists. -->

--- a/docn/cime_config/stream_definition_docn.xml
+++ b/docn/cime_config/stream_definition_docn.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <stream_data version="2.0" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <stream_entry name="prescribed">

--- a/drof/cime_config/config_component.xml
+++ b/drof/cime_config/config_component.xml
@@ -94,7 +94,7 @@
     <default_value>UNSET</default_value>
     <group>run_component_drof</group>
     <file>env_run.xml</file>
-    <desc>case name for coupler history data mode when DROF_MODE is CPLHIST mode</desc>
+    <desc>case name for coupler history data mode (only used when DROF_MODE is CPLHIST mode)</desc>
   </entry>
 
   <entry id="DROF_CPLHIST_YR_ALIGN">

--- a/drof/cime_config/namelist_definition_drof.xml
+++ b/drof/cime_config/namelist_definition_drof.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <entry id="streamslist">
@@ -46,7 +44,7 @@
     </values>
   </entry>
 
-  <entry id="model_meshfile"> 
+  <entry id="model_meshfile">
     <type>char</type>
     <category>streams</category>
     <input_pathname>abs</input_pathname>

--- a/drof/cime_config/stream_definition_drof.xml
+++ b/drof/cime_config/stream_definition_drof.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <stream_data version="2.0" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <stream_entry name="rof.diatren_ann_rx1">

--- a/dwav/cime_config/namelist_definition_dwav.xml
+++ b/dwav/cime_config/namelist_definition_dwav.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <entry_id version="2.0">
 
   <!-- Values to use by default for creation of DWAV model dwav namelists. -->

--- a/dwav/cime_config/stream_definition_dwav.xml
+++ b/dwav/cime_config/stream_definition_dwav.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
-
 <stream_data version="2.0" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <stream_entry name="climo">

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(cdeps_share  ${GenF90_SRCS}
                          shr_const_mod.F90
                          shr_orb_mod.F90
                          shr_log_mod.F90
+                         shr_lnd2rof_tracers_mod.F90
                          shr_strconvert_mod.F90
                          shr_precip_mod.F90
                          shr_string_mod.F90

--- a/share/shr_lnd2rof_tracers_mod.F90
+++ b/share/shr_lnd2rof_tracers_mod.F90
@@ -1,0 +1,94 @@
+module shr_lnd2rof_tracers_mod
+
+  !========================================================================
+  ! read lnd2rof_tracers_inparm namelist and sets up driver list of fields for
+  ! lnd -> river communications
+  !========================================================================
+
+  use ESMF         , only : ESMF_VMGetCurrent, ESMF_VM, ESMF_VMGet, ESMF_VMBroadcast
+  use ESMF         , only : ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU, ESMF_SUCCESS
+  use shr_sys_mod  , only : shr_sys_abort
+  use shr_log_mod  , only : shr_log_getLogUnit
+  use shr_kind_mod , only : r8 => shr_kind_r8, cs => shr_kind_cs
+  use shr_nl_mod   , only : shr_nl_find_group_name
+
+  implicit none
+  private
+
+  ! !PUBLIC MEMBER FUNCTIONS
+  public :: shr_lnd2rof_tracers_readnl       ! Read namelist
+
+  character(len=*), parameter :: &
+       u_FILE_u=__FILE__
+
+!====================================================================================
+CONTAINS
+!====================================================================================
+
+  subroutine shr_lnd2rof_tracers_readnl(NLFilename, lnd2rof_tracer_list)
+
+    ! input/output variables
+    character(len=*), intent(in)  :: NLFilename          ! Namelist filename
+    character(len=*), intent(out) :: lnd2rof_tracer_list ! Colon delimited string of liquid lnd2rof tracers
+
+    !----- local -----
+    type(ESMF_VM)      :: vm
+    integer            :: unitn                  ! namelist unit number
+    integer            :: ierr                   ! error code
+    logical            :: exists                 ! if file exists or not
+    integer            :: rc
+    integer            :: localpet
+    integer            :: mpicom
+    integer            :: logunit
+    character(len=CS)  :: lnd2rof_tracers
+    character(*),parameter :: subName = '(shr_lnd2rof_tracers_readnl) '
+    ! ------------------------------------------------------------------
+
+    namelist /lnd2rof_tracers_inparm/ lnd2rof_tracers
+
+    !-----------------------------------------------------------------------------
+    ! Read namelist and figure out the lnd2rof_tracers field list to pass
+    ! First check if file exists and if not, n_lnd2rof_tracers will be zero
+    !-----------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    !--- Open and read namelist ---
+    if ( len_trim(NLFilename) == 0 ) then
+       call shr_sys_abort( subName//'ERROR: nlfilename not set' )
+    end if
+    call shr_log_getLogUnit(logunit)
+
+    lnd2rof_tracers = ' '
+    lnd2rof_tracer_list = ' '
+
+    call ESMF_VMGetCurrent(vm, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+    call ESMF_VMGet(vm, localPet=localPet, mpiCommunicator=mpicom, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+
+    if (localpet==0) then
+       inquire(file=trim(NLFileName), exist=exists)
+       if ( exists ) then
+          open(newunit=unitn, file=trim(NLFilename), status='old' )
+          call shr_nl_find_group_name(unitn, 'lnd2rof_tracers_inparm', ierr)
+          if (ierr == 0) then
+             ! Note that if ierr /= 0, no namelist is present.
+             read(unitn, lnd2rof_tracers_inparm, iostat=ierr)
+             if (ierr > 0) then
+                call shr_sys_abort(trim(subName) //'problem of read of lnd2rof_tracers_inparm ')
+             endif
+          endif
+          close( unitn )
+       end if
+    end if
+    call ESMF_VMBroadcast(vm, lnd2rof_tracers, CS, 0, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=__FILE__)) return
+    
+    if (lnd2rof_tracers /= ' ') then
+       lnd2rof_tracer_list = trim(lnd2rof_tracers)
+    end if
+
+  end subroutine shr_lnd2rof_tracers_readnl
+
+end module shr_lnd2rof_tracers_mod

--- a/streams/dshr_methods_mod.F90
+++ b/streams/dshr_methods_mod.F90
@@ -14,7 +14,7 @@ module dshr_methods_mod
   use ESMF         , only : ESMF_TraceRegionEnter, ESMF_TraceRegionExit
   use shr_kind_mod , only : r8=>shr_kind_r8, cs=>shr_kind_cs, cl=>shr_kind_cl
   use shr_log_mod  , only : shr_log_error
-  
+
   implicit none
   public
 
@@ -54,6 +54,7 @@ contains
     integer          ,          intent(out)             :: rc
 
     ! local variables
+    integer                     :: ni, nj
     type(ESMF_Field)            :: lfield
     integer                     :: itemCount
     character(len=*), parameter :: subname='(dshr_state_getfldptr)'
@@ -74,7 +75,9 @@ contains
         if (chkerr(rc,__LINE__,u_FILE_u)) return
       else
         ! the call to just returns if it cannot find the field
-        call ESMF_LogWrite(trim(subname)//" Could not find the field: "//trim(fldname)//" just returning", ESMF_LOGMSG_INFO)
+         call ESMF_LogWrite(trim(subname)//" Could not find the field: "//trim(fldname)//&
+              " just returning", ESMF_LOGMSG_INFO)
+        return
       end if
     else
       call ESMF_StateGet(State, itemName=trim(fldname), field=lfield, rc=rc)
@@ -82,6 +85,19 @@ contains
 
       call dshr_field_getfldptr(lfield, fldptr1=fldptr1, fldptr2=fldptr2, rc=rc)
       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    end if
+
+    ! Initialize pointer value
+    if (present(fldptr1)) then
+       do ni = 1,size(fldptr1)
+          fldptr1(ni) = huge(1._r8)
+       end do
+    else if (present(fldptr2)) then
+       do nj = 1,size(fldptr2, dim=2)
+          do ni = 1,size(fldptr2, dim=1)
+             fldptr2(ni,nj) = huge(1._r8)
+          end do
+       end do
     end if
 
   end subroutine dshr_state_getfldptr

--- a/streams/dshr_methods_mod.F90
+++ b/streams/dshr_methods_mod.F90
@@ -41,6 +41,8 @@ contains
 
   subroutine dshr_state_getfldptr(State, fldname, fldptr1, fldptr2, allowNullReturn, rc)
 
+    use shr_infnan_mod, only: nan => shr_infnan_nan, assignment(=)
+
     ! ----------------------------------------------
     ! Get pointer to a state field
     ! ----------------------------------------------
@@ -50,7 +52,7 @@ contains
     character(len=*) ,          intent(in)              :: fldname
     real(R8)         , pointer, intent(inout), optional :: fldptr1(:)
     real(R8)         , pointer, intent(inout), optional :: fldptr2(:,:)
-    logical          ,          intent(in),optional     :: allowNullReturn
+    logical          ,          intent(in)   , optional :: allowNullReturn
     integer          ,          intent(out)             :: rc
 
     ! local variables
@@ -90,12 +92,12 @@ contains
     ! Initialize pointer value
     if (present(fldptr1)) then
        do ni = 1,size(fldptr1)
-          fldptr1(ni) = huge(1._r8)
+          fldptr1(ni) = nan
        end do
     else if (present(fldptr2)) then
        do nj = 1,size(fldptr2, dim=2)
           do ni = 1,size(fldptr2, dim=1)
-             fldptr2(ni,nj) = huge(1._r8)
+             fldptr2(ni,nj) = nan
           end do
        end do
     end if

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -412,7 +412,7 @@ contains
     call ESMF_MeshGet(sdat%model_mesh, spatialDim=spatialDim, &
          numOwnedElements=numOwnedElements, elementdistGrid=distGrid, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    allocate(ownedElemCoords(spatialDim*numOwnedElements))
+    allocate(ownedElemCoords(spatialDim*numOwnedElements), stat=istat)
     if ( istat /= 0 ) then
        call shr_log_error(subName//&
             ': allocation error for mesh ownedElemCoords with size '//toString(spatialDim*numOwnedElements), rc=rc)
@@ -426,13 +426,13 @@ contains
     end if
     call ESMF_MeshGet(sdat%model_mesh, ownedElemCoords=ownedElemCoords)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    allocate(sdat%model_lon(numOwnedElements))
+    allocate(sdat%model_lon(numOwnedElements), stat=istat)
     if ( istat /= 0 ) then
        call shr_log_error(subName//&
             ': allocation error for sdat%model_lon with size '//toString(numOwnedElements), rc=rc)
        return
     end if
-    allocate(sdat%model_lat(numOwnedElements))
+    allocate(sdat%model_lat(numOwnedElements), stat=istat)
     if ( istat /= 0 ) then
        call shr_log_error(subName//&
             ': allocation error for sdat%model_lat with size '//toString(numOwnedElements), rc=rc)
@@ -1747,7 +1747,7 @@ contains
              allocate(data_short2d(lsize, stream_nlev), stat=istat)
              if ( istat /= 0 ) then
                 call shr_log_error(subName//'allocation error of data_short2d with size '// &
-                     toString(lsize*stream_nlev), rc=istat)
+                     toString(lsize*stream_nlev), rc=rc)
                 return
              end if
           endif
@@ -1757,21 +1757,21 @@ contains
              allocate(data_real1d(lsize), stat=istat)
              if ( istat /= 0 ) then
                 call shr_log_error(subName//'allocation error of data_real1d with size '// &
-                     toString(lsize), rc=istat)
+                     toString(lsize), rc=rc)
                 return
              end if
           else if (pio_iovartype == PIO_DOUBLE .and. .not. allocated(data_dbl1d)) then
              allocate(data_dbl1d(lsize), stat=istat)
              if ( istat /= 0 ) then
                 call shr_log_error(subName//'allocation error of data_dbl1d with size '// &
-                     toString(lsize), rc=istat)
+                     toString(lsize), rc=rc)
                 return
              end if
           else if(pio_iovartype == PIO_SHORT .and. .not. allocated(data_short1d)) then
              allocate(data_short1d(lsize), stat=istat)
              if ( istat /= 0 ) then
                 call shr_log_error(subName//'allocation error of data_short1d with size '// &
-                     toString(lsize), rc=istat)
+                     toString(lsize), rc=rc)
                 return
              end if
           endif
@@ -2191,9 +2191,6 @@ contains
     do n = 1, ndims
        rcode = pio_inq_dimlen(pioid, dimids(n), dimlens(n))
     end do
-
-    ! Determine if there is a time dimension
-    rcode = pio_inq_dimname(pioid, dimids(ndims), dimname)
 
     ! determine compdof for stream
     call ESMF_MeshGet(per_stream%stream_mesh, elementdistGrid=distGrid, rc=rc)

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -2031,9 +2031,9 @@ contains
              gsize2d = dimlens(1)*dimlens(2)
           else
              write(6,*)'ERROR: dimlens= ',dimlens
-             call shr_log_error(trim(subname)//' only ndims of 3 and 4 &
-                  total dimensions are currently supported for multiple level fields &
-                  with a time dimension', rc=rc)
+             call shr_log_error(trim(subname)//' only ndims of 3 and 4 '//&
+                  ' total dimensions are currently supported for multiple level fields '// &
+                  ' with a time dimension', rc=rc)
              return
           end if
        else
@@ -2045,9 +2045,9 @@ contains
              gsize2d = dimlens(1)*dimlens(2)
           else
              write(6,*)'ERROR: dimlens= ',dimlens
-             call shr_log_error(trim(subname)//' only ndims of 2 and 3 &
-                  total dimensions are currently supported for multiple level fields &
-                  without a time dimension', rc=rc)
+             call shr_log_error(trim(subname)//' only ndims of 2 and 3'// &
+                  ' total dimensions are currently supported for multiple level fields'// &
+                  ' without a time dimension', rc=rc)
              return
           end if
        end if
@@ -2087,7 +2087,7 @@ contains
        else
           if (mainproc) then
              write(logunit,F01) 'setting iodesc for 2d: '//trim(fldname)// &
-                  ' with dimlens(1),dimlens(2) = ',dimlens(1),dimlens(2),&
+                  ' with dimlens(1),dimlens(2) = ',dimlens(1),dimlens(2), &
                   ' and the variable has no time or vertical dimension '
           end if
           call pio_initdecomp(sdat%pio_subsystem, pio_iovartype, (/dimlens(1),dimlens(2)/), compdof, &
@@ -2128,7 +2128,7 @@ contains
           else
              write(6,*)'ERROR: dimlens= ',dimlens
              call shr_log_error(trim(subname)//&
-                  ' the third dimension of a 3d field must be either time or a vertical level', rc-rc)
+                  ' the third dimension of a 3d field must be either time or a vertical level', rc=rc)
              return
           end if
        end if

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -815,9 +815,9 @@ contains
        write(sdat%logunit,'(2a,i0,a,i0)') subname, &
             'Stream: ',stream_index,' stream_nlev = ',stream_nlev
        if (stream_nlev /= 1) then
-          write(sdat%logunit,'(2a,i0,a)') subname, &
-               'Stream: ',stream_index,' has following vertical levels'
-          write(sdat%logunit,*) sdat%pstrm(stream_index)%stream_vlevs
+          write(sdat%logunit,'(2a,i0,a)') subname,&
+               'Stream: ',stream_index,' has following vertical levels '
+          write(sdat%logunit,*)sdat%pstrm(stream_index)%stream_vlevs
        end if
     end if
 
@@ -1293,7 +1293,7 @@ contains
                   algo=trim(sdat%stream(ns)%tinterpalgo), rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
              if (debug_level > 0 .and. sdat%mainproc) then
-                write(sdat%logunit,'(2a,i0,2(f10.5,2x))') &
+                write(sdat%logunit,'(2a,i0,2(2x,f10.5))') &
                      subname,' non-cosz-interp stream, flb, fub= ',ns,flb,fub
                 write(sdat%logunit,'(a)') '------------------------------------------------------'
              endif
@@ -1498,25 +1498,23 @@ contains
 
     ! write time bounds info
     if (debug_level > 0 .and. sdat%mainproc) then
-       if (debug_level > 0) then
-          write(sdat%logunit,'(2a,i0,a,l7,a,l7)') subname, &
-               'Stream: ',ns,&
-               ' find_bounds = ',find_bounds,' newdata is = ',newdata
-          write(sdat%logunit,'(2a,i0,a,4(2x,i0))') subname, &
-               'Stream: ',ns,&
-               ' oDateLB, OSecLb, oDateUB, OsecUB =  ',&
-               oDateLB, OSecLb, oDateUB, OsecUB
-          write(sdat%logunit,'(2a,i0,a,2x,3(f13.6,2x),l4)') subname, &
-               'Stream: ',ns,&
-               ' rdateLB,rdateM,rdateUB = ',&
-               rdateLB, rdateM, rdateUB
-          write(sdat%logunit,'(2a,i0,a,6(i0,2x))') subname, &
-               'Stream: ',ns,&
-               ' lbymd,lbsec,mdate,msec,ubymd,ubsec = ',&
-               sdat%pstrm(ns)%ymdLB, sdat%pstrm(ns)%todLB, &
-               mdate, msec, &
-               sdat%pstrm(ns)%ymdUB, sdat%pstrm(ns)%todUB
-       end if
+       write(sdat%logunit,'(2a,i0,a,l7,a,l7)') subname, &
+            'Stream: ',ns,&
+            ' find_bounds = ',find_bounds,' newdata is = ',newdata
+       write(sdat%logunit,'(2a,i0,a,4(2x,i0))') subname, &
+            'Stream: ',ns,&
+            ' oDateLB, OSecLb, oDateUB, OsecUB =  ',&
+            oDateLB, OSecLb, oDateUB, OsecUB
+       write(sdat%logunit,'(2a,i0,a,2x,3(f13.6,2x))') subname, &
+            'Stream: ',ns,&
+            ' rdateLB,rdateM,rdateUB = ',&
+            rdateLB, rdateM, rdateUB
+       write(sdat%logunit,'(2a,i0,a,6(i0,2x))') subname, &
+            'Stream: ',ns,&
+            ' lbymd,lbsec,mdate,msec,ubymd,ubsec = ',&
+            sdat%pstrm(ns)%ymdLB, sdat%pstrm(ns)%todLB, &
+            mdate, msec, &
+            sdat%pstrm(ns)%ymdUB, sdat%pstrm(ns)%todUB
     end if
 
     ! if newdata, determine if do a copy or read in new lower bound data
@@ -1831,7 +1829,7 @@ contains
              if (handlefill) then
                 ! Single point streams are not allowed to have missing values
                 if (stream%mapalgo == 'none' .and. any(data_real2d == fillvalue_r4)) then
-                   write(errmsg,'(2a)')' ERROR: _Fillvalue found in stream input variable: '//&
+                   write(errmsg,'(2a)')' ERROR: _Fillvalue found in stream input variable: ',&
                         trim(per_stream%fldlist_stream(nf))
                    if (sdat%mainproc) then
                       write(sdat%logunit,'(2a)') subname,trim(errmsg)
@@ -2051,7 +2049,7 @@ contains
 
        ! get lon and lat of stream u and v fields
        lsize = size(dataptr1d)
-       allocate(dataptr(lsize))
+       allocate(dataptr(lsize), stat=istat)
        if ( istat /= 0 ) then
           call shr_log_error(subName//'allocation error of dataptr with size '// &
                toString(lsize), rc=rc)
@@ -2217,12 +2215,15 @@ contains
           return
        end if
        ! Assume that first 2 dimensions correspond to the compdof
+       rcode = pio_inq_dimname(pioid, dimids(ndims), dimname)
        if (trim(dimname) == 'time' .or. trim(dimname) == 'nt') then
           if (ndims == 3) then
              ! second dimension is lev and third dimension is time
+             ! this would then corresond to an unstructured grid with just ncol
              gsize2d = dimlens(1)
           else if (ndims == 4) then
              ! third dimension is lev and fourth dimension is time
+             ! first two dimensions are lon,lat
              gsize2d = dimlens(1)*dimlens(2)
           else
              call shr_log_error(subname//' only ndims of 3 and 4 '//&

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -2279,25 +2279,12 @@ contains
 
     ! local variables
     integer :: ns, nf, ni, nj
-<<<<<<< HEAD
-    integer :: logunit
-    logical :: mainproc
     logical :: found
     character(len=*), parameter :: subname='(shr_strdata_get_stream_pointer_2d) '
-    character(*)    , parameter :: F00 = "('(shr_strdata_get_stream_pointer_2d) ',8a)"
-=======
-    logical :: found
-    character(len=*), parameter :: subname='(shr_strdata_get_stream_pointer_2d) '
->>>>>>> mvertens/feature/fix_unstructured_multilev_input
     ! ----------------------------------------------
 
     rc = ESMF_SUCCESS
 
-<<<<<<< HEAD
-    logunit = sdat%stream(1)%logunit
-    mainproc = sdat%mainproc
-=======
->>>>>>> mvertens/feature/fix_unstructured_multilev_input
     found = .false.
 
     ! loop over all input streams and determine if the strm_fld is in the field bundle of the target stream
@@ -2317,20 +2304,12 @@ contains
     if (found) then
        ! If pointer found, preset value
        if (mainproc) then
-<<<<<<< HEAD
-          write(logunit,F00)' strm_ptr is allocated and preset to huge for stream field strm_'//trim(strm_fld)
-       end if
-       do nj = 1,size(strm_ptr, dim=2)
-          do ni = 1,size(strm_ptr, dim=1)
-             strm_ptr(ni,nj) = huge(1._r8)
-=======
           write(logout,'(2a)') trim(subname), &
                ' strm_ptr is allocated and preset to nan for stream field strm_'//trim(strm_fld)
        end if
        do nj = 1,size(strm_ptr, dim=2)
           do ni = 1,size(strm_ptr, dim=1)
              strm_ptr(ni,nj) = nan
->>>>>>> mvertens/feature/fix_unstructured_multilev_input
           end do
        end do
     else
@@ -2339,11 +2318,7 @@ contains
           if (requirePointer) then
              if (present(errmsg)) then
                 if (mainproc) then
-<<<<<<< HEAD
-                   write(logunit,F00) trim(errmsg)
-=======
                    write(logout,'(2a)') trim(subname),trim(errmsg)
->>>>>>> mvertens/feature/fix_unstructured_multilev_input
                 end if
              end if
              call shr_log_error(subName//"ERROR: pointer not found for "//trim(strm_fld), rc=rc)

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -2127,7 +2127,8 @@ contains
                   per_stream%stream_pio_iodesc)
           else
              write(6,*)'ERROR: dimlens= ',dimlens
-             call shr_log_error(trim(subname)//' the third dimension of a 3d field must be either time or a vertical level')
+             call shr_log_error(trim(subname)//&
+                  ' the third dimension of a 3d field must be either time or a vertical level', rc-rc)
              return
           end if
        end if
@@ -2146,13 +2147,13 @@ contains
                per_stream%stream_pio_iodesc)
        else
           write(6,*)'ERROR: dimlens= ',dimlens
-          call shr_log_error(trim(subname)//' dimlens = 4 assumes a time dimension and a vertical dimension')
+          call shr_log_error(trim(subname)//' dimlens = 4 assumes a time dimension and a vertical dimension', rc=rc)
           return
        end if
 
     else
        write(6,*)'ERROR: dimlens= ',dimlens
-       call shr_log_error(trim(subname)//' only ndims of 2 and 3 and 4 are currently supported')
+       call shr_log_error(trim(subname)//' only ndims of 2 and 3 and 4 are currently supported', rc=rc)
        return
     end if
 
@@ -2183,9 +2184,7 @@ contains
     integer :: logunit
     logical :: mainproc
     logical :: found
-    integer :: logunit
-    logical :: mainproc
-    character(len=*), parameter :: subname='(shr_strdata_get_stream_pointer_1d)'
+    character(len=*), parameter :: subname='(shr_strdata_get_stream_pointer_1d) '
     character(*)    , parameter :: F00 = "('(shr_strdata_get_stream_pointer_1d) ',8a)"
     ! ----------------------------------------------
 
@@ -2251,9 +2250,7 @@ contains
     integer :: logunit
     logical :: mainproc
     logical :: found
-    integer :: logunit
-    logical :: mainproc
-    character(len=*), parameter :: subname='(shr_strdata_get_stream_pointer_2d)'
+    character(len=*), parameter :: subname='(shr_strdata_get_stream_pointer_2d) '
     character(*)    , parameter :: F00 = "('(shr_strdata_get_stream_pointer_2d) ',8a)"
     ! ----------------------------------------------
 

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -368,7 +368,7 @@ contains
     nstrms = tmp(1)
 
     if (.not. isroot_task) then
-       allocate(streamdat(nstrms), stat=istat)
+       allocate(streamdat(nstrms))
     endif
 
     ! Set the logunit and mainproc attributes for each stream
@@ -918,7 +918,8 @@ contains
     if (cycle) then
        dYear  = yrFirst + modulo(mYear-yrAlign+(2*nYears),nYears)   ! current data year
        if(debug_level>0 .and. strm%mainproc) then
-          write(strm%logunit,'(2a,4(i0,2x))') subname, ' dyear, yrfirst, myear, yralign, nyears = ', &
+          write(strm%logunit,'(2a,5(i0,2x))') subname, &
+               ' dyear, yrfirst, myear, yralign, nyears = ', &
                dyear, yrfirst, myear, yralign, nyears
        endif
     else
@@ -937,7 +938,7 @@ contains
     if (debug_level>0 .and. strm%mainproc) then
        write(strm%logunit,'(2a,3(i0,2x),f20.4)') subname, &
             ' mYear,dYear,dDateIn,rDateIn  = ',mYear,dYear,dDateIn,rDateIn
-       write(strm%logunit,'(a,4(i0,2x))') subname, &
+       write(strm%logunit,'(2a,4(i0,2x))') subname, &
             ' yrFirst,yrLast,yrAlign,nYears= ',yrFirst,yrLast,yrAlign,nYears
     endif
 
@@ -1433,7 +1434,7 @@ contains
           din = strm%file(k)%date(n)
           sin = strm%file(k)%secs(n)
           if (debug_level > 5 .and. strm%mainproc) then
-             write(strm%logunit,'(2a,4(i0,2x))') subname,&
+             write(strm%logunit,'(2a,5(i0,2x))') subname,&
                   ' before shr_cal_advDateInt: offset,n,k,strm%file(k)%date(n),strm%file(k)%sec(n) = ',&
              offin,n,k,strm%file(k)%date(n),strm%file(k)%secs(n)
           end if
@@ -2104,8 +2105,8 @@ contains
                    rsfname = streams(k)%file(n)%name(index(streams(k)%file(n)%name, '/',.true.):)
                    if (trim(rfname) /= trim(rsfname)) then
                       if (streams(k)%mainproc) then
-                         write(streams(k)%logunit,'(2a)') subname,trim(rfname), '<>', trim(rsfname)
-                         write(streams(k)%logunit,'(2a)') subname,' fname = '//trim(fname)
+                         write(streams(k)%logunit,'(4a)') subname,trim(rfname), '<>', trim(rsfname)
+                         write(streams(k)%logunit,'(3a)') subname,' fname = ',trim(fname)
                          write(streams(k)%logunit,'(2a,i0,2x,i0,2x,a)') subname,' k,n,streams(k)%file(n)%name = ',&
                               k,n,trim(streams(k)%file(n)%name)
                       end if

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -205,7 +205,6 @@ contains
     integer                  :: status
     integer                  :: tmp(6)
     real(r8)                 :: rtmp(1)
-    integer                  :: istat
     character(len=*),parameter   :: subName = '(shr_stream_init_from_xml) '
     ! --------------------------------------------------------
 

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -290,7 +290,7 @@ contains
           if(associated(p)) then
              call extractDataContent(p, streamdat(i)%yearAlign)
           else
-             call shr_sys_abort(subname//" yearAlign must be provided", rc=rc)
+             call shr_sys_abort(subname//" yearAlign must be provided")
              return
           endif
 
@@ -760,7 +760,7 @@ contains
                 ' with size '//toString(streamdat(i)%nfiles), rc=rc)
            return
         end if
-        allocate(strm_tmpstrings(streamdat(i)%nfiles), stat=istat)
+        allocate(strm_tmpstrings(streamdat(i)%nfiles))
         call ESMF_ConfigGetAttribute(CF,valueList=strm_tmpstrings, label="stream_data_files"//mystrm//':', rc=rc)
         if (ChkErr(rc,__LINE__,u_FILE_u)) return
         do n=1,streamdat(i)%nfiles


### PR DESCRIPTION
### Description of changes

This introduces the following new stream modules that are optional and can be added to the datamode streams already in place:

### Specific notes
The following new modules have been added
 - datm_pres_aero_mod.F90
 - datm_pres_co2_mod.F90
 - datm_pres_ndep_mod.F90
 - datm_pres_o3_mod.F90

For datm_pres_ndep_mod.F90:
- also added new nitrogen deposition cmip7 stream which be accessed by the settings for `DATM_PRESNDEP`:  `clim_1850_cmip7 `and `hist_cmip7`.  These are currently **not the default** and need to be set vial an `xmlchange `command - e.g. `./xmlchage DATM_PRESNDEP=clim_1850_cmip7`. Also note that for the cmip7 data, no unit conversion is done whereas for the default cmip6 data the input data is converted from` g/m2/sec` to `kg/m2/sec`.

For datm_pres_co2_mod.F90:   
- added the following logic which will change answers for non-CPLHIST mode
```F90
  if (datamode == 'CPLHIST') then
       Sa_co2diag(:) = strm_Sa_co2diag(:)
       Sa_co2prog(:) = strm_Sa_co2prog(:)
  else
       ! This is intentional since we don't have any Sa_co2prog - but for now
       ! will set Sa_co2prog equal to Sa_co2diag
       Sa_co2diag(:) = strm_Sa_co2diag(:)
       Sa_co2prog(:) = strm_Sa_co2diag(:)
  end if
```

Also removed references to water isotopes in DATM since this will be refactored in upcoming work.

Contributors other than yourself, if any: None

CDEPS Issues Fixed: #30 

Are there dependencies on other component PRs: No

Are changes expected to change answers (bfb): bfb unless the cmip7 ndep is used, or when datm_pres_co2 is used

Any User Interface Changes: add new options for DATM_PRESNDEP

Testing performed:
- ran aux_cdeps_noresm and compared to noresm3_0_beta09 
   - the only diffs were for CO2_PROG which has been changed based on the above.
- ran aux_blom_noresm and compared to noresm3_0_beta09
   -  all results are bfb as well as expected fails EXCEPT for the ndep fields and Sa_co2prog fields from DATM
- ran aux_clm_noresm and compared to ctsm5.4.002_noresm_v1 
   - everything is bfb - but diffs are that atmImp_Sa_co2prog and lndExp_Sa_co2prog are both nonzero, and  lndExp_Sa_o3 is now on the mediator history files 
 
Hashes used for testing:
noresm3_0_beta09 with the above cdeps branch
