### PR TITLE
new mapfile mapalgo as option

### DIFF
--- a/cime_config/stream_cdeps.py
+++ b/cime_config/stream_cdeps.py
@@ -344,7 +344,8 @@ class StreamCDEPS(GenericXML):
 
                         # Check that key is valid
                         expect(
-                            mod_dict[var_key] in valid_values[var_key],
+                            (mod_dict[var_key] in valid_values[var_key]) or
+                            (var_key == 'mapalgo' and 'mapfile:' in mod_dict[var_key]),
                             "{} can only have values of {} for stream {} in file {}".format(
                                 var_key,
                                 valid_values[var_key],

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -677,7 +677,7 @@ contains
                   srcTermProcessing=srcTermProcessing_Value, ignoreDegenerate=.true., &
                   unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, rc=rc)
           else if (trim(sdat%stream(ns)%mapalgo(1:8)) == 'mapfile:') then
-             mapfile = trim(sdat%stream(ns)%mapalgo(9:len_trim(sdat%stream(ns)%mapalgo)))
+             mapfile = trim(sdat%stream(ns)%mapalgo(9:))
              call ESMF_FieldSMMStore(sdat%pstrm(ns)%field_stream, lfield_dst, mapfile, &
                   routehandle=sdat%pstrm(ns)%routehandle, &
                   ignoreUnmatchedIndices=.true., &

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -601,7 +601,6 @@ contains
                   unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, rc=rc)
           else if (trim(sdat%stream(ns)%mapalgo(1:8)) == 'mapfile:') then
              mapfile = trim(sdat%stream(ns)%mapalgo(9:len_trim(sdat%stream(ns)%mapalgo)))
-             write(6,'(a)')'DEBUG: mapfile = '//trim(mapfile)
              call ESMF_FieldSMMStore(sdat%pstrm(ns)%field_stream, lfield_dst, mapfile, &
                   routehandle=sdat%pstrm(ns)%routehandle, &
                   ignoreUnmatchedIndices=.true., &

--- a/streams/dshr_strdata_mod.F90
+++ b/streams/dshr_strdata_mod.F90
@@ -91,13 +91,13 @@ module dshr_strdata_mod
   ! note that the fields in fldbun_stream_lb and fldbun_stream_ub contain the the names fldlist_model
 
   type shr_strdata_perstream
-     character(CL)                       :: stream_meshfile                 ! stream mesh file from stream txt file
+     character(len=CL)                   :: stream_meshfile                 ! stream mesh file from stream txt file
      type(ESMF_Mesh)                     :: stream_mesh                     ! stream mesh created from stream mesh file
      type(io_desc_t)                     :: stream_pio_iodesc               ! stream pio descriptor
      logical                             :: stream_pio_iodesc_set =.false.  ! true=>pio iodesc has been set
      type(ESMF_RouteHandle)              :: routehandle                     ! stream n -> model mesh mapping
-     character(CL), allocatable          :: fldlist_stream(:)               ! names of stream file fields
-     character(CL), allocatable          :: fldlist_model(:)                ! names of stream model fields
+     character(len=CL), allocatable      :: fldlist_stream(:)               ! names of stream file fields
+     character(len=CL), allocatable      :: fldlist_model(:)                ! names of stream model fields
      integer                             :: stream_nlev                     ! number of vertical levels in stream
      real(r8), allocatable               :: stream_vlevs(:)                 ! values of vertical levels in stream
      integer                             :: stream_lb                       ! index of the Lowerbound (LB) in fldlist_stream
@@ -134,7 +134,7 @@ module dshr_strdata_mod
      integer, pointer               :: model_gindex(:)                 ! model global index spzce
      integer                        :: model_gsize                     ! model global domain size
      type(ESMF_CLock)               :: model_clock                     ! model clock
-     character(CL)                  :: model_calendar = shr_cal_noleap ! model calendar for ymd,tod
+     character(len=CL)              :: model_calendar = shr_cal_noleap ! model calendar for ymd,tod
      integer                        :: ymd, tod                        ! model time
      type(iosystem_desc_t), pointer :: pio_subsystem => null()         ! pio info
      real(r8)                       :: eccen  = SHR_ORB_UNDEF_REAL     ! cosz t-interp info
@@ -457,9 +457,9 @@ contains
     ! local variables
     type(ESMF_Mesh), pointer     :: stream_mesh
     type(ESMF_CalKind_Flag)      :: esmf_caltype    ! esmf calendar type
-    character(CS)                :: calendar        ! calendar name
+    character(len=CS)            :: calendar        ! calendar name
     integer                      :: ns              ! stream index
-    character(CX)                :: fileName        ! generic file name
+    character(len=CX)            :: fileName        ! generic file name
     integer                      :: nfld            ! loop stream field index
     type(ESMF_Field)             :: lfield          ! temporary
     type(ESMF_Field)             :: lfield_dst      ! temporary
@@ -468,8 +468,8 @@ contains
     type(ESMF_VM)                :: vm
     integer                      :: nvars
     integer                      :: i, stream_nlev, index, istat
-    character(CL)                :: stream_vector_names
-    character(CL)                :: mapfile
+    character(len=CL)            :: stream_vector_names
+    character(len=CL)            :: mapfile
     character(len=*), parameter  :: subname='(shr_sdat_init)'
     ! ----------------------------------------------
 
@@ -769,12 +769,12 @@ contains
     type(ESMF_VM)           :: vm
     type(file_desc_t)       :: pioid
     integer                 :: rcode
-    character(CX)           :: filename
+    character(len=CX)       :: filename
     integer                 :: dimid
     type(var_desc_t)        :: varid
     integer                 :: stream_nlev
     integer                 :: old_handle    ! previous setting of pio error handling
-    character(CS)           :: units
+    character(len=CS)       :: units
     integer                 :: istat
     character(len=*), parameter :: subname = '(shr_strdata_get_stream_nlev) '
     ! ----------------------------------------------
@@ -851,7 +851,7 @@ contains
     type(var_desc_t)        :: varid
     type(file_desc_t)       :: pioid
     integer                 :: rcode
-    character(CX)           :: filename
+    character(len=CX)       :: filename
     type(io_desc_t)         :: pio_iodesc
     real(r4), allocatable   :: data_real(:)
     real(r8), allocatable   :: data_double(:)
@@ -999,7 +999,7 @@ contains
     real(r8), pointer                   :: data_v_dst(:)    ! pointer into field bundle
     type(ESMF_Time)                     :: timeLB, timeUB   ! lb and ub times
     type(ESMF_TimeInterval)             :: timeint          ! delta time
-    character(CL)                       :: calendar
+    character(len=CL)                   :: calendar
     integer                             :: dday             ! delta days
     real(r8)                            :: dtime            ! delta time
     integer                             :: year,month,day   ! date year month day
@@ -1457,12 +1457,12 @@ contains
     real(r8)                             :: rDateM,rDateLB,rDateUB  ! model,LB,UB dates with fractional days
     integer                              :: n_lb, n_ub
     integer                              :: i
-    character(CX)                        :: filename_lb
-    character(CX)                        :: filename_ub
-    character(CX)                        :: filename_next
-    character(CX)                        :: filename_prev
+    character(len=CX)                    :: filename_lb
+    character(len=CX)                    :: filename_ub
+    character(len=CX)                    :: filename_next
+    character(len=CX)                    :: filename_prev
     logical                              :: find_bounds
-    character(len=*), parameter              :: subname = '(shr_strdata_readLBUB) '
+    character(len=*), parameter          :: subname = '(shr_strdata_readLBUB) '
     !-------------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -1596,7 +1596,7 @@ contains
     ! local variables
     integer                  :: stream_nlev
     type(ESMF_Field)         :: field_dst
-    character(CX)            :: currfile
+    character(len=CX)        :: currfile
     logical                  :: fileexists
     logical                  :: fileopen
     type(file_desc_t)        :: pioid
@@ -1628,10 +1628,10 @@ contains
     real(r8)                 :: coslat, coslon
     real(r8)                 :: scale_factor, add_offset
     integer(i2)              :: fillvalue_i2
-    character(CS)            :: uname, vname
+    character(len=CS)        :: uname, vname
     integer                  :: i, lev
     logical                  :: checkflag = .false.
-    character(CL)            :: errmsg
+    character(len=CL)        :: errmsg
     integer                  :: istat
     character(len=*), parameter  :: subname = '(shr_strdata_readstrm) '
     !-------------------------------------------------------------------------------
@@ -2158,7 +2158,7 @@ contains
     integer                 :: n, m, cnt
     type(var_desc_t)        :: varid
     integer                 :: ndims
-    character(CS)           :: dimname
+    character(len=CS)       :: dimname
     integer, allocatable    :: dimids(:)
     integer, allocatable    :: dimlens(:)
     type(ESMF_DistGrid)     :: distGrid

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -244,7 +244,6 @@ contains
           p => item(getElementsByTagname(streamnode, "mapalgo"), 0)
           if (associated(p)) then
              call extractDataContent(p, streamdat(i)%mapalgo)
-             write(6,*)'DEBUG: shr_stream_mapalgo = '//trim(streamdat(i)%mapalgo)
              if (streamdat(i)%mapalgo /= shr_stream_mapalgo_bilinear .and. &
                  streamdat(i)%mapalgo /= shr_stream_mapalgo_redist   .and. &
                  streamdat(i)%mapalgo /= shr_stream_mapalgo_nn       .and. &
@@ -252,7 +251,8 @@ contains
                  streamdat(i)%mapalgo /= shr_stream_mapalgo_consd    .and. &
                  streamdat(i)%mapalgo(1:8) /= shr_stream_mapalgo_mapfile .and. &
                  streamdat(i)%mapalgo /= shr_stream_mapalgo_none) then
-                call shr_log_error("mapaglo must have a value of either bilinear, redist, nn, consf or consd", rc=rc)
+                call shr_log_error("mapaglo must have a value of either bilinear, redist, nn, consf, consd or "//&
+                     " mapalgo(1:8) must equal mapfile: ", rc=rc)
                 return
              end if
           endif

--- a/streams/dshr_stream_mod.F90
+++ b/streams/dshr_stream_mod.F90
@@ -63,32 +63,32 @@ module dshr_stream_mod
   public :: shr_stream_dataDump          ! internal stream data for debugging
   public :: shr_stream_restIO            ! read or write to netcdf restart file
 
-  character(CS),parameter,public :: shr_stream_file_null    = 'not_set'
+  character(len=CS),parameter,public :: shr_stream_file_null    = 'not_set'
 
   ! valid values for time extrapoloation
-  character(CS),parameter,public :: shr_stream_taxis_cycle  = 'cycle'
-  character(CS),parameter,public :: shr_stream_taxis_extend = 'extend'
-  character(CS),parameter,public :: shr_stream_taxis_limit  = 'limit'
+  character(len=CS),parameter,public :: shr_stream_taxis_cycle  = 'cycle'
+  character(len=CS),parameter,public :: shr_stream_taxis_extend = 'extend'
+  character(len=CS),parameter,public :: shr_stream_taxis_limit  = 'limit'
 
   ! valid values for time interpolation
-  character(CS),parameter,public :: shr_stream_tinterp_lower   = 'lower'
-  character(CS),parameter,public :: shr_stream_tinterp_upper   = 'upper'
-  character(CS),parameter,public :: shr_stream_tinterp_nearest = 'nearest'
-  character(CS),parameter,public :: shr_stream_tinterp_linear  = 'linear'
-  character(CS),parameter,public :: shr_stream_tinterp_coszen  = 'coszen'
+  character(len=CS),parameter,public :: shr_stream_tinterp_lower   = 'lower'
+  character(len=CS),parameter,public :: shr_stream_tinterp_upper   = 'upper'
+  character(len=CS),parameter,public :: shr_stream_tinterp_nearest = 'nearest'
+  character(len=CS),parameter,public :: shr_stream_tinterp_linear  = 'linear'
+  character(len=CS),parameter,public :: shr_stream_tinterp_coszen  = 'coszen'
 
   ! valid values for mapping interpolation
-  character(CS),parameter,public :: shr_stream_mapalgo_bilinear = 'bilinear'
-  character(CS),parameter,public :: shr_stream_mapalgo_redist   = 'redist'
-  character(CS),parameter,public :: shr_stream_mapalgo_nn       = 'nn'
-  character(CS),parameter,public :: shr_stream_mapalgo_consf    = 'consf'
-  character(CS),parameter,public :: shr_stream_mapalgo_consd    = 'consd'
-  character(CL),parameter,public :: shr_stream_mapalgo_mapfile  = 'mapfile:'
-  character(CS),parameter,public :: shr_stream_mapalgo_none     = 'none'
+  character(len=CS),parameter,public :: shr_stream_mapalgo_bilinear = 'bilinear'
+  character(len=CS),parameter,public :: shr_stream_mapalgo_redist   = 'redist'
+  character(len=CS),parameter,public :: shr_stream_mapalgo_nn       = 'nn'
+  character(len=CS),parameter,public :: shr_stream_mapalgo_consf    = 'consf'
+  character(len=CS),parameter,public :: shr_stream_mapalgo_consd    = 'consd'
+  character(len=CL),parameter,public :: shr_stream_mapalgo_mapfile  = 'mapfile:'
+  character(len=CS),parameter,public :: shr_stream_mapalgo_none     = 'none'
 
   ! a useful derived type to use inside shr_streamType ---
   type shr_stream_file_type
-     character(CX)         :: name = shr_stream_file_null ! the file name (full pathname)
+     character(len=CX)     :: name = shr_stream_file_null ! the file name (full pathname)
      logical               :: haveData = .false.          ! has t-coord data been read in?
      integer               :: nt = 0                      ! size of time dimension
      integer  ,allocatable :: date(:)                     ! t-coord date: yyyymmdd
@@ -97,8 +97,8 @@ module dshr_stream_mod
   end type shr_stream_file_type
 
   type shr_stream_data_variable
-     character(CS) :: nameinfile
-     character(CS) :: nameinmodel
+     character(len=CS) :: nameinfile
+     character(len=CS) :: nameinmodel
   end type shr_stream_data_variable
 
   type shr_stream_streamType
@@ -113,15 +113,15 @@ module dshr_stream_mod
      integer           :: yearFirst    = -1                     ! first year to use in t-axis (yyyymmdd)
      integer           :: yearLast     = -1                     ! last  year to use in t-axis (yyyymmdd)
      integer           :: yearAlign    = -1                     ! align yearFirst with this model year
-     character(CS)     :: lev_dimname  = 'null'                 ! name of vertical dimension if any
-     character(CS)     :: taxMode      = shr_stream_taxis_cycle ! cycling option for time axis
-     character(CS)     :: tInterpAlgo  = 'linear'               ! algorithm to use for time interpolation
-     character(CL)     :: mapalgo      = 'bilinear'             ! type of mapping - default is 'bilinear'
-     character(CS)     :: readMode     = 'single'               ! stream read model - 'single' or 'full_file'
+     character(len=CS) :: lev_dimname  = 'null'                 ! name of vertical dimension if any
+     character(len=CS) :: taxMode      = shr_stream_taxis_cycle ! cycling option for time axis
+     character(len=CS) :: tInterpAlgo  = 'linear'               ! algorithm to use for time interpolation
+     character(len=CL) :: mapalgo      = 'bilinear'             ! type of mapping - default is 'bilinear'
+     character(len=CS) :: readMode     = 'single'               ! stream read model - 'single' or 'full_file'
      real(r8)          :: dtlimit      = 1.5_r8                 ! delta time ratio limits for time interpolation
      integer           :: offset       = 0                      ! offset in seconds of stream data
-     character(CS)     :: calendar     = shr_cal_noleap         ! stream calendar (obtained from first stream data file)
-     character(CL)     :: meshFile     = ' '                    ! filename for mesh for all fields on stream (full pathname)
+     character(len=CS) :: calendar     = shr_cal_noleap         ! stream calendar (obtained from first stream data file)
+     character(len=CL)     :: meshFile     = ' '                    ! filename for mesh for all fields on stream (full pathname)
      integer           :: k_lvd        = -1                     ! file/sample of least valid date
      integer           :: n_lvd        = -1                     ! file/sample of least valid date
      logical           :: found_lvd    = .false.                ! T <=> k_lvd,n_lvd have been set
@@ -129,9 +129,9 @@ module dshr_stream_mod
      integer           :: n_gvd        = -1                     ! file/sample of greatest valid date
      logical           :: found_gvd    = .false.                ! T <=> k_gvd,n_gvd have been set
      logical           :: fileopen     = .false.                ! is current file open
-     character(CX)     :: currfile     = ' '                    ! current filename
+     character(len=CX) :: currfile     = ' '                    ! current filename
      integer           :: nvars                                 ! number of stream variables
-     character(CL)     :: stream_vectors = 'null'               ! stream vectors names
+     character(len=CL) :: stream_vectors = 'null'               ! stream vectors names
      type(file_desc_t) :: currpioid                             ! current pio file desc
      type(shr_stream_file_type)    , allocatable :: file(:)     ! filenames of stream data files (full pathname)
      type(shr_stream_data_variable), allocatable :: varlist(:)  ! stream variable names (on file and in model)
@@ -515,7 +515,7 @@ contains
     integer       :: nfiles
     integer       :: nvars
     integer       :: istat
-    character(CS) :: calendar ! stream calendar
+    character(len=CS) :: calendar ! stream calendar
     character(len=*),parameter :: subName = '(shr_stream_init_from_inline) '
     ! --------------------------------------------------------
 
@@ -1315,7 +1315,7 @@ contains
     integer,optional            ,intent(out)   :: rc   ! return code
 
     ! local variables
-    character(CX)          :: fileName    ! filename to read
+    character(len=CX)      :: fileName    ! filename to read
     integer                :: nt
     integer                :: num,n
     integer                :: din,dout
@@ -1323,15 +1323,15 @@ contains
     integer                :: lrc
     integer                :: vid,ndims,rcode
     integer,allocatable    :: dids(:)
-    character(CS)          :: units,calendar
-    character(CS)          :: bunits        ! time units (days,secs,...)
+    character(len=CS)      :: units,calendar
+    character(len=CS)      :: bunits        ! time units (days,secs,...)
     integer                :: bdate         ! base date: calendar date
     real(R8)               :: bsec          ! base date: elapsed secs
     integer                :: ndate         ! calendar date of time value
     integer                :: old_handle    ! previous setting of pio error handling
     real(R8)               :: nsec          ! elapsed secs on calendar date
     real(R8),allocatable   :: tvar(:)
-    character(CX)          :: msg
+    character(len=CX)      :: msg
     integer                :: istat
     character(len=*),parameter :: subname = '(shr_stream_readTCoord) '
     !-------------------------------------------------------------------------------
@@ -1645,8 +1645,8 @@ contains
 
     ! local
     integer                :: vid, n
-    character(CX)          :: fileName
-    character(CL)          :: lcal
+    character(len=CX)      :: fileName
+    character(len=CL)      :: lcal
     integer(PIO_OFFSET_KIND) :: attlen
     integer                :: old_handle
     integer                :: rCode


### PR DESCRIPTION
### Description of changes

### Specific notes
This PR provides a new mapfile algorithm as a new option for mapping the streams input to the component model resolution.
The new scheme does not have a default but is enabled via adding the following in the appropriate user_nl_XXX_streams where the user needs to fill in the entries in <> below:
<stream_name>:mapalgo = "mapfile:<path to mapping file>
As an example:
`rof.ryf8485_jra:mapalgo="mapfile:/cluster/shared/noresm/inputdata/cpl/cpl6/map_JRA025_to_tnx1v4_e1000r300_170928.nc"`

This PR enables a significant speedup in stand-alone ocean simulations. See https://github.com/NorESMhub/BLOM/issues/686#issuecomment-3723714486.

Contributors other than yourself, if any: None

CDEPS Issues Fixed: None

Are there dependencies on other component PRs (if so list): No

Are changes expected to change answers: bfb - except if you run the drof on the ocean grid.

Any User Interface Changes (namelist or namelist defaults changes): New mapfile options for streams (see above)

Testing performed: 
`PFS.a%TL319_l%null_oi%tnx1v4_r%tnx1v4_w%null_z%null_g%null_m%tnx1v4.NOIIAJRARYF8485OC.betzy_intel`
and added in `user_nl_drof_streams` 
`rof.ryf8485_jra:mapalgo="mapfile:/cluster/shared/noresm/inputdata/cpl/cpl6/map_JRA025_to_tnx1v4_e1000r300_170928.nc"`

Hashes used for testing: noresm3_0_beta09 and this PR.

