### PR TITLE
DGLC default will be ais8:gis4 with new mesh files

### DIFF
--- a/dglc/cime_config/namelist_definition_dglc.xml
+++ b/dglc/cime_config/namelist_definition_dglc.xml
@@ -39,9 +39,9 @@
     <input_pathname>abs</input_pathname>
     <group>dglc_nml</group>
     <values>
-      <value glc_grid="ais8:gris4">$DIN_LOC_ROOT/glc/cism/Antarctica/ISMIP6_Antarctica_8km.init.c210908.nc:$DIN_LOC_ROOT/glc/cism/Greenland/greenland_4km_epsg3413_c251001.nc</value>
-      <value glc_grid="gris4" >$DIN_LOC_ROOT/glc/cism/Greenland/greenland_4km_epsg3413_c251001.nc</value>
-      <value glc_grid="ais8"  >$DIN_LOC_ROOT/glc/cism/Antarctica/ISMIP6_Antarctica_8km.init.c210908.nc</value>
+      <value glc_grid="ais8:gris4">$DIN_LOC_ROOT/glc/cism/Antarctica/antarctica_8km_epsg3031_c20250403.nc:$DIN_LOC_ROOT/glc/cism/Greenland/greenland_4km_epsg3413_c20250227.nc</value>
+      <value glc_grid="gris4">$DIN_LOC_ROOT/glc/cism/Greenland/greenland_4km_epsg3413_c20250227.nc</value>
+      <value glc_grid="ais8" >$DIN_LOC_ROOT/glc/cism/Antarctica/antarctica_8km_epsg3031_c20250403.nc</value>
     </values>
     <desc>
       colon deliminted string of inputdata files
@@ -83,8 +83,8 @@
     <category>streams</category>
     <group>dglc_nml</group>
     <values>
-      <value glc_grid="ais8:gris4">704,421</value>
-      <value glc_grid="ais8">704</value>
+      <value glc_grid="ais8:gris4">761,421</value>
+      <value glc_grid="ais8">761</value>
       <value glc_grid="gris4">421</value>
       <value glc_grid="gris20">76</value>
     </values>
@@ -99,8 +99,8 @@
     <category>streams</category>
     <group>dglc_nml</group>
     <values>
-      <value glc_grid="ais8:gris4">576,721</value>
-      <value glc_grid="ais8">576</value>
+      <value glc_grid="ais8:gris4">761,721</value>
+      <value glc_grid="ais8">761</value>
       <value glc_grid="gris4">721</value>
       <value glc_grid="gris20">141</value>
     </values>


### PR DESCRIPTION
### Description of changes
This PR is needed to accompany the PR https://github.com/NorESMhub/ccs_config_noresm/pull/76.
This was first raised in issue https://github.com/NorESMhub/CTSM/issues/158#issuecomment-3436748968.

With this PR and the ccs_config_noresm PR , the standard DGLC%NOEVOLVE compset now includes Antarctica as well (g%ais8:gris4) and the new Greenland and Antarctic grids and mesh files will be used.

### Specific notes
This PR enables the following user_nl_dglc to be obtained out of the box:
```
datamode = "noevolve"
model_datafiles_list = "/cluster/shared/noresm/inputdata/glc/cism/Antarctica/antarctica_8km_epsg3031_c20250403.nc:/cluster/shared/noresm/inputdata/glc/cism/Greenland/greenland_4km_epsg3413_c20250227.nc"
model_internal_gridsize = 8000, 4000
model_meshfiles_list = "/cluster/shared/noresm/inputdata/share/meshes/antarctica_8km_epsg3031_ESMFmesh_c20250303.nc:/cluster/shared/noresm/inputdata/share/meshes/greenland_4km_epsg3413_ESMFmesh_c20250303.nc"
nx_global = 761, 421
ny_global = 761, 721
```

Contributors other than yourself, if any: @mpetrini-norce

CDEPS Issues Fixed:

Are there dependencies on other component PRs:  https://github.com/NorESMhub/ccs_config_noresm/pull/76.

Are changes expected to change answers: Yes

Any User Interface Changes (namelist or namelist defaults changes): Yes - see above description.

Testing performed (e.g. aux_cdeps, CESM prealpha, etc):
Testing is currently ongoing and will be summarized here.
noresm_prealpha: all tests PASS but differences with respect to noresm3_0_beta12a (as expected)
aux_cam_noresm: all tests PASS but differences with respect to noresm3_0_beta12 (as expected)
aux_ctsm_noresm: all tests PASS and are bfb with respect to ctsm5.4.002_noresm_v4

Hashes used for testing:
noresm3_0_beta12a with changes to ccs_config to be https://github.com/NorESMhub/ccs_config_noresm/pull/76.
and the code in this PR.